### PR TITLE
feat(synology-drive-api): Add directory and file content types

### DIFF
--- a/synology_drive_api/api.go
+++ b/synology_drive_api/api.go
@@ -17,10 +17,12 @@ const MyDrive = SynologyDriveFileID("/mydrive/")
 type contentType string
 
 const ContentTypeDocument = contentType("document")
+const ContentTypeDirectory = contentType("dir")
+const ContentTypeFile = contentType("file")
 
 func (c contentType) isValid() bool {
 	switch c {
-	case ContentTypeDocument:
+	case ContentTypeDocument, ContentTypeDirectory, ContentTypeFile:
 		return true
 	default:
 		return false

--- a/synology_drive_api/api_test.go
+++ b/synology_drive_api/api_test.go
@@ -2,6 +2,7 @@ package synology_drive_api
 
 import (
 	"os"
+	"testing"
 )
 
 func getEnvOrPanic(key string) string {
@@ -22,4 +23,25 @@ func getNasUser() string {
 
 func getNasPass() string {
 	return getEnvOrPanic("SYNOLOGY_NAS_PASS")
+}
+
+func TestContentTypeIsValid(t *testing.T) {
+	tests := []struct {
+		name string
+		ct   contentType
+		want bool
+	}{
+		{"ContentTypeDocument", ContentTypeDocument, true},
+		{"ContentTypeDirectory", ContentTypeDirectory, true},
+		{"ContentTypeFile", ContentTypeFile, true},
+		{"Invalid content type", contentType("invalid"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ct.isValid(); got != tt.want {
+				t.Errorf("contentType.isValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/synology_drive_api/list.go
+++ b/synology_drive_api/list.go
@@ -75,7 +75,7 @@ type ListResponseItemV2 struct {
 
 type ListResponseDataV2 struct {
 	Items []ListResponseItemV2 `json:"items"`
-	Total int64                `json:"total"`
+	Total int                  `json:"total"`
 }
 
 type ListResponseV2 struct {

--- a/synology_drive_api/list_test.go
+++ b/synology_drive_api/list_test.go
@@ -14,6 +14,12 @@ func TestList(t *testing.T) {
 	require.Nil(t, err)
 	resp, err := s.List(MyDrive)
 	require.Nil(t, err)
-	assert.Equal(t, int64(1), resp.Total)
-	t.Log(resp.Items)
+
+	for _, item := range resp.Items {
+		t.Log(item.FileID, item.DisplayPath, item.Name, item.Path, item.ContentType)
+		assert.NotEmpty(t, item.FileID)
+		assert.NotEmpty(t, item.Name)
+		assert.NotEmpty(t, item.Path)
+		t.Log(item.ContentType)
+	}
 }


### PR DESCRIPTION
- Add ContentTypeDirectory and ContentTypeFile constants
- Update contentType.isValid() to accept new content types
- Add unit tests for content type validation
- Enhance list_test to validate response items
- Change Total field type from int64 to int in ListResponseDataV2