### PR TITLE
Improve git commit prompt rules

### DIFF
--- a/.github/prompts/git-commit-rule.prompt.md
+++ b/.github/prompts/git-commit-rule.prompt.md
@@ -2,4 +2,4 @@
 - Run pre-commit hooks and fix any errors.
 - When executing git diff commands, include the --no-pager option. (i.e. git --no-pager diff --staged)
 - Draft a commit message in English based on the staged changes.
-- Ask for confirmation before committing with the proposed message, and proceed only with user approval.
+- Ask for confirmation before committing with the proposed message using a "y/n" prompt, and proceed only with user approval.


### PR DESCRIPTION
- Format the instructions as a bulleted list for better readability
- Clarify wording by changing "non-staged" to "unstaged" files
- Add instruction to include the --no-pager option when executing git diff commands
- Include example syntax for git diff command
- Add requirement to ask for confirmation before committing