### PR TITLE
chore: minor improvement in prompts

### DIFF
--- a/.github/prompts/git-commit-rule.prompt.md
+++ b/.github/prompts/git-commit-rule.prompt.md
@@ -1,10 +1,10 @@
-## Prompt
+## Steps
 1. If there are unstaged files, display the list and ask for the next step.
   - stop (default)
   - add unstaged files and proceed
   - ignore unstaged files and proceed
   and proceed only after receiving user approval.
-2. Run pre-commit hooks and fix any errors.
+2. Run pre-commit command and fix errors found.
 3. Draft a commit message in English based on the staged changes.
 4. Ask for confirmation before committing with the proposed message using a "y/n" prompt, and proceed only with user approval.
 5. commit the change and push it to the upstream.


### PR DESCRIPTION
This pull request updates the `.github/prompts/git-commit-rule.prompt.md` file to improve clarity and accuracy in the commit process instructions. The key changes involve renaming a section and refining the language for specific steps.

Improvements to commit process instructions:

* Renamed the section header from `## Prompt` to `## Steps` for better alignment with the content.
* Updated step 2 to replace "Run pre-commit hooks and fix any errors" with "Run pre-commit command and fix errors found," making the instruction more precise.