### PR TITLE
chore: Add pre-commit target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,14 @@ GO_BUILD := go build
 GO_TEST := go test
 
 # Declare phony targets that don't produce files
-.PHONY: build test clean run
+.PHONY: build test clean run pre-commit
 
 # Build the export command
 build:
 	$(GO_BUILD) -o bin/export cmd/export/main.go
+
+pre-commit:
+	pre-commit run --all-files
 
 # Run tests, specifically library unit tests
 test:


### PR DESCRIPTION
This pull request updates the `Makefile` to include a new `pre-commit` target and ensures it is properly declared as a phony target. The most important changes are:

### Additions to `Makefile` targets:

* Added a new `pre-commit` target that runs pre-commit checks across all files.
* Declared the `pre-commit` target as a phony target to prevent conflicts with files of the same name.