### PR TITLE
refactor(tests): improve assertion readability in test files\n\nRepla…

### DIFF
--- a/synology_drive_api/auth_test.go
+++ b/synology_drive_api/auth_test.go
@@ -10,20 +10,20 @@ import (
 func TestAuth(t *testing.T) {
 	t.Run("Login", func(t *testing.T) {
 		s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		err = s.Login()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.False(t, s.sessionExpired())
 		assert.NotEmpty(t, s.sid)
 	})
 
 	t.Run("Logout", func(t *testing.T) {
 		s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		err = s.Login()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		err = s.Logout()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.True(t, s.sessionExpired())
 		assert.Empty(t, s.sid)
 	})

--- a/synology_drive_api/export_test.go
+++ b/synology_drive_api/export_test.go
@@ -9,15 +9,15 @@ import (
 
 func TestExport(t *testing.T) {
 	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Test fails since the session is not logged in
 	_, err = s.Export("882614125167948399")
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	// Test should succeed after logging in, but we haven't implemented the Export function yet
 	err = s.Login()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	res, err := s.Export("882614125167948399")
 	// Skip the test if there was an error
 	if err != nil {
@@ -27,7 +27,7 @@ func TestExport(t *testing.T) {
 	t.Log("Response [Name]:", string(res.Name))
 	// Save the response to a file
 	err = os.WriteFile(res.Name, res.Content, 0644)
-	require.Nil(t, err, "Failed to save file")
+	require.NoError(t, err, "Failed to save file")
 	defer func() {
 		os.Remove(res.Name)
 	}()

--- a/synology_drive_api/get_test.go
+++ b/synology_drive_api/get_test.go
@@ -9,17 +9,17 @@ import (
 
 func TestGet(t *testing.T) {
 	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Test fails since the session is not logged in
 	_, err = s.Get("882614125167948399")
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	// Test succeeds after logging in
 	err = s.Login()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	resp, err := s.Get("882614125167948399")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, resp.raw)
 
 	//t.Log("Response:", string(resp.raw))

--- a/synology_drive_api/list_test.go
+++ b/synology_drive_api/list_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestList(t *testing.T) {
 	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = s.Login()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	resp, err := s.List(MyDrive)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// t.Log("Response:", string(resp.raw))
 	for _, item := range resp.Items {

--- a/synology_drive_api/session_test.go
+++ b/synology_drive_api/session_test.go
@@ -18,7 +18,7 @@ func TestHttpGet(t *testing.T) {
 		"session": "SynologyDrive",
 		"format":  "cookie",
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Verify the structure of the URL but exclude the password
 	expectedUrl := getNasUrl() + "/webapi/auth.cgi"

--- a/synology_drive_exporter/download_history_test.go
+++ b/synology_drive_exporter/download_history_test.go
@@ -76,7 +76,7 @@ func TestLoadFromReader(t *testing.T) {
 		]
 	}`
 	err = history.loadFromReader(strings.NewReader(json))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	item := history.Items["/path/to/file.odoc"]
 	require.NotNil(t, item)


### PR DESCRIPTION
This pull request refactors test assertions across multiple test files in the `synology_drive_api` package to use `require.NoError` and `require.Error` instead of `require.Nil` and `require.NotNil`. This change improves code readability and aligns with modern Go testing practices.

### Refactoring of test assertions:

* **Authentication Tests**:
  - Updated `TestAuth` in `auth_test.go` to replace `require.Nil` with `require.NoError` for error checks during login and logout processes.

* **Export Functionality Tests**:
  - Updated `TestExport` in `export_test.go` to replace `require.Nil` with `require.NoError` for error checks during login and file-saving operations, and `require.NotNil` with `require.Error` for expected errors before login. [[1]](diffhunk://#diff-c54f858213ff801abe18efbfddd5e901584e4d99b24cf31d81fcf4d69e025e1eL12-R20) [[2]](diffhunk://#diff-c54f858213ff801abe18efbfddd5e901584e4d99b24cf31d81fcf4d69e025e1eL30-R30)

* **Get Functionality Tests**:
  - Updated `TestGet` in `get_test.go` to replace `require.Nil` with `require.NoError` for error checks during login and data retrieval, and `require.NotNil` with `require.Error` for expected errors before login.

* **List Functionality Tests**:
  - Updated `TestList` in `list_test.go` to replace `require.Nil` with `require.NoError` for error checks during login and listing operations.

* **Other Tests**:
  - Updated `TestHttpGet` in `session_test.go` to replace `require.Nil` with `require.NoError` for error checks during HTTP request validation.
  - Updated `TestLoadFromReader` in `download_history_test.go` to replace `require.Nil` with `require.NoError` for error checks during JSON parsing.…ced  and  with  and  respectively in the following test files:\n- synology_drive_api/auth_test.go\n- synology_drive_api/export_test.go\n- synology_drive_api/get_test.go\n- synology_drive_api/list_test.go\n- synology_drive_api/session_test.go\n- synology_drive_exporter/download_history_test.go\n\nThis change enhances the clarity of test assertions, making the intent more explicit.