### PR TITLE
Add export statistics and improve error handling 

### DIFF
--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -15,12 +15,12 @@ const Version = "0.1.0"
 
 func init() {
 	if err := godotenv.Load(); err != nil {
-		log.Println("No .env file found, relying on environment variables")
+		fmt.Println("No .env file found, relying on environment variables")
 	}
 }
 
 func main() {
-	log.Println("Starting Synology Office Exporter...")
+	fmt.Println("Starting Synology Office Exporter...")
 
 	// Define command-line flags
 	userFlag := flag.String("user", "", "Synology NAS username")

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -84,17 +84,35 @@ func main() {
 	}
 
 	exitCode := 0
-	if err := exporter.ExportMyDrive(); err != nil {
+
+	if stats, err := exporter.ExportMyDrive(); err != nil {
 		exitCode = 1
 		log.Printf("Export failed: %v", err)
+	} else {
+		fmt.Printf("[MyDrive] Downloaded: %d, Skipped: %d, Ignored: %d, Errors: %d\n", stats.Downloaded, stats.Skipped, stats.Ignored, stats.Errors)
+		if stats.Errors > 0 {
+			exitCode = 1
+		}
 	}
-	if err := exporter.ExportTeamFolder(); err != nil {
+
+	if stats, err := exporter.ExportTeamFolder(); err != nil {
 		exitCode = 1
 		log.Printf("Export failed: %v", err)
+	} else {
+		fmt.Printf("[TeamFolder] Downloaded: %d, Skipped: %d, Ignored: %d, Errors: %d\n", stats.Downloaded, stats.Skipped, stats.Ignored, stats.Errors)
+		if stats.Errors > 0 {
+			exitCode = 1
+		}
 	}
-	if err := exporter.ExportSharedWithMe(); err != nil {
+
+	if stats, err := exporter.ExportSharedWithMe(); err != nil {
 		exitCode = 1
 		log.Printf("Export failed: %v", err)
+	} else {
+		fmt.Printf("[SharedWithMe] Downloaded: %d, Skipped: %d, Ignored: %d, Errors: %d\n", stats.Downloaded, stats.Skipped, stats.Ignored, stats.Errors)
+		if stats.Errors > 0 {
+			exitCode = 1
+		}
 	}
 
 	log.Println("Export complete")

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -57,7 +57,7 @@ func main() {
 	// Check if directory exists
 	if stat, err := os.Stat(downloadDir); err != nil || !stat.IsDir() {
 		if err != nil {
-			log.Printf("Warning: Download directory '%s' does not exist. Attempting to create it.", downloadDir)
+			fmt.Printf("Warning: Download directory '%s' does not exist. Attempting to create it.", downloadDir)
 			if err := os.MkdirAll(downloadDir, 0755); err != nil {
 				log.Fatalf("Failed to create download directory: %v", err)
 			}
@@ -71,7 +71,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to resolve absolute path of download directory: %v", err)
 	}
-	log.Printf("Files will be downloaded to: %s", downloadDir)
+	fmt.Printf("Files will be downloaded to: %s", downloadDir)
 
 	if user == "" || pass == "" || url == "" {
 		log.Fatalf("Missing required parameters: user, pass, and url must be provided either as flags or environment variables")
@@ -87,7 +87,7 @@ func main() {
 
 	if stats, err := exporter.ExportMyDrive(); err != nil {
 		exitCode = 1
-		log.Printf("Export failed: %v", err)
+		fmt.Printf("Export failed: %v", err)
 	} else {
 		fmt.Printf("[MyDrive] Downloaded: %d, Skipped: %d, Ignored: %d, Errors: %d\n", stats.Downloaded, stats.Skipped, stats.Ignored, stats.Errors)
 		if stats.Errors > 0 {
@@ -97,7 +97,7 @@ func main() {
 
 	if stats, err := exporter.ExportTeamFolder(); err != nil {
 		exitCode = 1
-		log.Printf("Export failed: %v", err)
+		fmt.Printf("Export failed: %v", err)
 	} else {
 		fmt.Printf("[TeamFolder] Downloaded: %d, Skipped: %d, Ignored: %d, Errors: %d\n", stats.Downloaded, stats.Skipped, stats.Ignored, stats.Errors)
 		if stats.Errors > 0 {
@@ -107,7 +107,7 @@ func main() {
 
 	if stats, err := exporter.ExportSharedWithMe(); err != nil {
 		exitCode = 1
-		log.Printf("Export failed: %v", err)
+		fmt.Printf("Export failed: %v", err)
 	} else {
 		fmt.Printf("[SharedWithMe] Downloaded: %d, Skipped: %d, Ignored: %d, Errors: %d\n", stats.Downloaded, stats.Skipped, stats.Ignored, stats.Errors)
 		if stats.Errors > 0 {
@@ -115,6 +115,6 @@ func main() {
 		}
 	}
 
-	log.Println("Export complete")
+	fmt.Println("Export complete")
 	os.Exit(exitCode)
 }

--- a/synology_drive_exporter/download_history.go
+++ b/synology_drive_exporter/download_history.go
@@ -14,9 +14,26 @@ import (
 const HISTORY_VERSION = 2
 const HISTORY_MAGIC = "SYNOLOGY_OFFICE_EXPORTER"
 
+type counter struct {
+	count int
+}
+
+func (c *counter) Increment() {
+	c.count++
+}
+
+func (c *counter) Get() int {
+	return c.count
+}
+
 type DownloadHistory struct {
 	Items map[string]DownloadItem
 	path  string
+
+	DownloadCount counter
+	SkippedCount  counter
+	IgnoredCount  counter
+	ErrorCount    counter
 }
 
 type jsonHeader struct {

--- a/synology_drive_exporter/download_history.go
+++ b/synology_drive_exporter/download_history.go
@@ -26,6 +26,15 @@ func (c *counter) Get() int {
 	return c.count
 }
 
+// ExportStats holds the statistics of the export operation.
+type ExportStats struct {
+	Downloaded int // Number of successfully downloaded files
+	Skipped    int // Number of skipped files (already up-to-date)
+	Ignored    int // Number of ignored files (not exportable)
+	Errors     int // Number of errors occurred
+}
+
+// DownloadHistory manages the download state and statistics.
 type DownloadHistory struct {
 	Items map[string]DownloadItem
 	path  string
@@ -34,6 +43,16 @@ type DownloadHistory struct {
 	SkippedCount  counter
 	IgnoredCount  counter
 	ErrorCount    counter
+}
+
+// GetStats returns the current export statistics.
+func (d *DownloadHistory) GetStats() ExportStats {
+	return ExportStats{
+		Downloaded: d.DownloadCount.Get(),
+		Skipped:    d.SkippedCount.Get(),
+		Ignored:    d.IgnoredCount.Get(),
+		Errors:     d.ErrorCount.Get(),
+	}
 }
 
 type jsonHeader struct {

--- a/synology_drive_exporter/error.go
+++ b/synology_drive_exporter/error.go
@@ -49,8 +49,11 @@ func (e DownloadHistoryParseError) Error() string {
 	return "failed to parse download history JSON: " + strconv.Quote(string(e))
 }
 
-type ExportFileWriteError string
+type ExportFileWriteError struct {
+	Op  string // operation description
+	Err error  // underlying error
+}
 
 func (e ExportFileWriteError) Error() string {
-	return "failed to write export file: " + strconv.Quote(string(e))
+	return fmt.Sprintf("failed to write export file [%s]: %v", e.Op, e.Err)
 }

--- a/synology_drive_exporter/error.go
+++ b/synology_drive_exporter/error.go
@@ -1,6 +1,23 @@
 package synology_drive_exporter
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
+
+// DownloadHistoryOperationError is returned when a download history operation fails.
+type DownloadHistoryOperationError struct {
+	Op  string // operation description
+	Err error  // underlying error
+}
+
+func (e *DownloadHistoryOperationError) Error() string {
+	return fmt.Sprintf("download history operation error [%s]: %v", e.Op, e.Err)
+}
+
+func (e *DownloadHistoryOperationError) Unwrap() error {
+	return e.Err
+}
 
 type DownloadHistoryFileError string
 

--- a/synology_drive_exporter/exporter.go
+++ b/synology_drive_exporter/exporter.go
@@ -28,12 +28,12 @@ func (fs *DefaultFileSystem) CreateFile(filename string, data []byte, dirPerm os
 	// Create parent directories if they don't exist
 	dir := filepath.Dir(filename)
 	if err := os.MkdirAll(dir, dirPerm); err != nil {
-		return ExportFileWriteError(fmt.Sprintf("failed to create directories for %s: %v", filename, err))
+		return ExportFileWriteError{Op: fmt.Sprintf("MkdirAll for %s", dir), Err: err}
 	}
 
 	// Write data to the file
 	if err := os.WriteFile(filename, data, filePerm); err != nil {
-		return ExportFileWriteError(fmt.Sprintf("failed to write to file %s: %v", filename, err))
+		return ExportFileWriteError{Op: fmt.Sprintf("WriteFile for %s", filename), Err: err}
 	}
 
 	return nil
@@ -219,13 +219,13 @@ func (e *Exporter) processFile(item ExportItem, history *DownloadHistory) {
 	fmt.Printf("Exporting file: %s\n", exportName)
 	resp, err := e.session.Export(item.FileID)
 	if err != nil {
-		fmt.Printf("failed to export %s: %v", exportName, err)
+		fmt.Printf("failed to export %s: %v\n", exportName, err)
 		history.ErrorCount.Increment()
 		return
 	}
 	downloadPath := filepath.Join(e.downloadDir, localPath)
 	if err := e.fs.CreateFile(downloadPath, resp.Content, 0755, 0644); err != nil {
-		fmt.Printf("failed to write file %s: %v", downloadPath, err)
+		fmt.Printf("failed to write file %s: %v\n", downloadPath, err)
 		history.ErrorCount.Increment()
 		return
 	}

--- a/synology_drive_exporter/exporter.go
+++ b/synology_drive_exporter/exporter.go
@@ -88,8 +88,6 @@ func NewExporterWithDependencies(session SessionInterface, downloadDir string, f
 
 // ExportMyDrive exports all convertible files from the user's Synology Drive and saves them to the download directory.
 // Download history is used to avoid duplicate downloads.
-// ExportMyDrive exports all convertible files from the user's Synology Drive and saves them to the download directory.
-// Download history is used to avoid duplicate downloads.
 func (e *Exporter) ExportMyDrive() (ExportStats, error) {
 	return e.ExportRootsWithHistory(
 		[]synd.FileID{synd.MyDrive},
@@ -97,8 +95,6 @@ func (e *Exporter) ExportMyDrive() (ExportStats, error) {
 	)
 }
 
-// ExportTeamFolder exports all convertible files from all team folders.
-// Download history is used to avoid duplicate downloads.
 // ExportTeamFolder exports all convertible files from all team folders.
 // Download history is used to avoid duplicate downloads.
 func (e *Exporter) ExportTeamFolder() (ExportStats, error) {
@@ -118,8 +114,6 @@ func (e *Exporter) ExportTeamFolder() (ExportStats, error) {
 
 // ExportSharedWithMe exports all convertible files and directories shared with the user.
 // Download history is used to avoid duplicate downloads.
-// ExportSharedWithMe exports all convertible files and directories shared with the user.
-// Download history is used to avoid duplicate downloads.
 func (e *Exporter) ExportSharedWithMe() (ExportStats, error) {
 	sharedWithMe, err := e.session.SharedWithMe()
 	if err != nil {
@@ -135,8 +129,6 @@ func (e *Exporter) ExportSharedWithMe() (ExportStats, error) {
 // exportItemsWithHistory is a common internal helper for exporting a slice of ExportItem with download history management.
 // It handles DownloadHistory creation, loading, saving, and calls processItem for each item.
 // This function is used by both ExportRootsWithHistory and ExportSharedWithMe to avoid code duplication.
-// exportItemsWithHistory is a common internal helper for exporting a slice of ExportItem with download history management.
-// It handles DownloadHistory creation, loading, saving, and calls processItem for each item.
 // Returns ExportStats and error (wrapped in DownloadHistoryOperationError if relevant).
 func (e *Exporter) exportItemsWithHistory(
 	items []ExportItem,
@@ -159,8 +151,6 @@ func (e *Exporter) exportItemsWithHistory(
 	return history.GetStats(), nil
 }
 
-// ExportRootsWithHistory is a wrapper for exporting multiple root directories with download history management.
-// It converts rootIDs to ExportItem and delegates to exportItemsWithHistory.
 // ExportRootsWithHistory is a wrapper for exporting multiple root directories with download history management.
 // It converts rootIDs to ExportItem and delegates to exportItemsWithHistory.
 func (e *Exporter) ExportRootsWithHistory(

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -144,7 +144,7 @@ func TestExporterExportMyDrive(t *testing.T) {
 		{
 			name:          "Error when getting list",
 			listError:     errors.New("list error"),
-			expectedError: true,
+			expectedFiles: 0,
 		},
 		{
 			name: "Error during export",
@@ -578,10 +578,7 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 				Hash:        tc.itemHash,
 			}
 			exporter := NewExporterWithDependencies(session, "", mockFS)
-			err := exporter.processItem(item, history, false)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			exporter.processItem(item, history)
 			if writeCalled != tc.expectWrite {
 				t.Errorf("expected write: %v, got: %v", tc.expectWrite, writeCalled)
 			}

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -450,7 +450,7 @@ func TestExporterExportMyDrive(t *testing.T) {
 			defer os.RemoveAll(dir)
 
 			// Run the test
-			err = exporter.ExportMyDrive()
+			stats, err := exporter.ExportMyDrive()
 
 			// Assertions
 			if tt.expectedError && err == nil {
@@ -460,10 +460,16 @@ func TestExporterExportMyDrive(t *testing.T) {
 				t.Errorf("Unexpected error occurred: %v", err)
 			}
 
-			// Validate file write count
-			if len(mockFS.WrittenFiles) != tt.expectedFiles {
-				t.Errorf("Expected %d files to be written, but got %d",
-					tt.expectedFiles, len(mockFS.WrittenFiles))
+			// Validate file write count matches stats.Downloaded
+			if len(mockFS.WrittenFiles) != stats.Downloaded {
+				t.Errorf("Expected %d files to be written (stats.Downloaded), but got %d",
+					stats.Downloaded, len(mockFS.WrittenFiles))
+			}
+			if stats.Downloaded != tt.expectedFiles {
+				t.Errorf("Expected stats.Downloaded=%d, but got %d", tt.expectedFiles, stats.Downloaded)
+			}
+			if tt.expectedError && stats.Errors == 0 {
+				t.Errorf("Expected stats.Errors > 0, but got %d", stats.Errors)
 			}
 
 			// Check if all expected directories were traversed

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"maps"
-
 	synd "github.com/isseis/go-synology-office-exporter/synology_drive_api"
 )
 
@@ -511,17 +509,142 @@ func TestExporterExportMyDrive(t *testing.T) {
 }
 
 // validateExportedFile checks that a file was exported correctly by inspecting the mock file system.
-// This function is a test helper and its implementation is omitted here for brevity.
 func validateExportedFile(t *testing.T, item *synd.ResponseItem, mockFS *MockFileSystem, exportErrors map[synd.FileID]error, fileOpError error) {
 	// Implementation omitted for this test; see above for details.
 }
 
-/*
-TestExportItem_HistoryAndHash covers:
-1. Skips download if history exists and hash is the same
-2. Downloads if history exists and hash is different
-3. Downloads if history does not exist
-*/
+// newTestDownloadHistory creates a DownloadHistory instance for testing.
+func newTestDownloadHistory(items map[string]DownloadItem) *DownloadHistory {
+	if items == nil {
+		items = make(map[string]DownloadItem)
+	}
+	return &DownloadHistory{
+		Items: items,
+	}
+}
+
+// TestExporter_Counts verifies that DownloadHistory's counters are incremented correctly.
+func TestExporter_Counts(t *testing.T) {
+	fileID := synd.FileID("file1")
+	fileHash := synd.FileHash("hash1")
+	fileID2 := synd.FileID("file2")
+	fileHash2 := synd.FileHash("hash2")
+	ignoredFileID := synd.FileID("file3")
+	ignoredPath := "/doc/ignored.txt" // not exportable
+	exportName := synd.GetExportFileName("/doc/test1.odoc")
+	cleanPath := strings.TrimPrefix(filepath.Clean(exportName), "/")
+
+	t.Run("DownloadCount increments on successful export", func(t *testing.T) {
+		session := &MockSynologySession{
+			ExportFunc: func(fid synd.FileID) (*synd.ExportResponse, error) {
+				return &synd.ExportResponse{Content: []byte("file content")}, nil
+			},
+		}
+		mockFS := NewMockFileSystem()
+		history := newTestDownloadHistory(nil)
+		item := ExportItem{
+			Type:        synd.ObjectTypeFile,
+			FileID:      fileID,
+			DisplayPath: "/doc/test1.odoc",
+			Hash:        fileHash,
+		}
+		exporter := NewExporterWithDependencies(session, "", mockFS)
+		exporter.processItem(item, history)
+		if got := history.DownloadCount.Get(); got != 1 {
+			t.Errorf("DownloadCount = %d, want 1", got)
+		}
+	})
+
+	t.Run("SkippedCount increments if file is already exported with same hash", func(t *testing.T) {
+		session := &MockSynologySession{
+			ExportFunc: func(fid synd.FileID) (*synd.ExportResponse, error) {
+				return &synd.ExportResponse{Content: []byte("file content")}, nil
+			},
+		}
+		mockFS := NewMockFileSystem()
+		history := newTestDownloadHistory(map[string]DownloadItem{
+			cleanPath: {FileID: fileID, Hash: fileHash},
+		})
+		item := ExportItem{
+			Type:        synd.ObjectTypeFile,
+			FileID:      fileID,
+			DisplayPath: "/doc/test1.odoc",
+			Hash:        fileHash,
+		}
+		exporter := NewExporterWithDependencies(session, "", mockFS)
+		exporter.processItem(item, history)
+		if got := history.SkippedCount.Get(); got != 1 {
+			t.Errorf("SkippedCount = %d, want 1", got)
+		}
+	})
+
+	t.Run("IgnoredCount increments if file is not exportable", func(t *testing.T) {
+		session := &MockSynologySession{}
+		mockFS := NewMockFileSystem()
+		history := newTestDownloadHistory(nil)
+		item := ExportItem{
+			Type:        synd.ObjectTypeFile,
+			FileID:      ignoredFileID,
+			DisplayPath: ignoredPath,
+			Hash:        fileHash,
+		}
+		exporter := NewExporterWithDependencies(session, "", mockFS)
+		exporter.processItem(item, history)
+		if got := history.IgnoredCount.Get(); got != 1 {
+			t.Errorf("IgnoredCount = %d, want 1", got)
+		}
+	})
+
+	t.Run("ErrorCount increments if export fails", func(t *testing.T) {
+		session := &MockSynologySession{
+			ExportFunc: func(fid synd.FileID) (*synd.ExportResponse, error) {
+				return nil, errors.New("export failed")
+			},
+		}
+		mockFS := NewMockFileSystem()
+		history := newTestDownloadHistory(nil)
+		item := ExportItem{
+			Type:        synd.ObjectTypeFile,
+			FileID:      fileID2,
+			DisplayPath: "/doc/test2.odoc",
+			Hash:        fileHash2,
+		}
+		exporter := NewExporterWithDependencies(session, "", mockFS)
+		exporter.processItem(item, history)
+		if got := history.ErrorCount.Get(); got != 1 {
+			t.Errorf("ErrorCount = %d, want 1", got)
+		}
+	})
+
+	t.Run("ErrorCount increments if file write fails", func(t *testing.T) {
+		session := &MockSynologySession{
+			ExportFunc: func(fid synd.FileID) (*synd.ExportResponse, error) {
+				return &synd.ExportResponse{Content: []byte("file content")}, nil
+			},
+		}
+		mockFS := NewMockFileSystem()
+		mockFS.CreateFileFunc = func(filename string, data []byte, dirPerm os.FileMode, filePerm os.FileMode) error {
+			return errors.New("write failed")
+		}
+		history := newTestDownloadHistory(nil)
+		item := ExportItem{
+			Type:        synd.ObjectTypeFile,
+			FileID:      fileID2,
+			DisplayPath: "/doc/test2.odoc",
+			Hash:        fileHash2,
+		}
+		exporter := NewExporterWithDependencies(session, "", mockFS)
+		exporter.processItem(item, history)
+		if got := history.ErrorCount.Get(); got != 1 {
+			t.Errorf("ErrorCount = %d, want 1", got)
+		}
+	})
+}
+
+// TestExportItem_HistoryAndHash covers:
+// 1. Skips download if history exists and hash is the same
+// 2. Downloads if history exists and hash is different
+// 3. Downloads if history does not exist
 func TestExportItem_HistoryAndHash(t *testing.T) {
 	fileID := synd.FileID("file1")
 	fileHashOld := synd.FileHash("hash_old")
@@ -569,8 +692,7 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 				writeCalled = true
 				return nil
 			}
-			history := &DownloadHistory{Items: make(map[string]DownloadItem)}
-			maps.Copy(history.Items, tc.history)
+			history := newTestDownloadHistory(tc.history)
 			item := ExportItem{
 				Type:        synd.ObjectTypeFile,
 				FileID:      fileID,


### PR DESCRIPTION
This pull request introduces significant improvements to the Synology Office Exporter, focusing on enhanced error handling, detailed export statistics, and improved test coverage. The key changes include replacing `log` with `fmt` for output consistency, introducing an `ExportStats` struct to track export operation metrics, and refactoring the export process to handle multiple tasks more robustly. Additionally, new tests validate the correctness of the export statistics and error handling.

### Improvements to export process and statistics:
* Added `ExportStats` struct to track metrics such as downloaded, skipped, ignored, and error counts during export operations. Updated the `DownloadHistory` class to maintain counters for these metrics and return them via a new `GetStats` method. (`synology_drive_exporter/download_history.go`, [synology_drive_exporter/download_history.goR17-R55](diffhunk://#diff-9d16800cf6ebb850b308317702830e377f3433fbae6f32edc225e3719280d959R17-R55))
* Refactored export methods (`ExportMyDrive`, `ExportTeamFolder`, `ExportSharedWithMe`) to return `ExportStats` and handle errors more effectively. Errors are now logged and counted without halting the process. (`synology_drive_exporter/exporter.go`, [[1]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L91-R91) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L100-R103) [[3]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L117-R120) [[4]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047R132-R159)
* Introduced a task-based loop in `main` to sequentially execute export tasks and print detailed statistics for each task. (`cmd/export/main.go`, [cmd/export/main.goL87-R111](diffhunk://#diff-ec447938ff5ceca7abc5424272d18e5a9c1cec2fdf3b0b45a42169d19e757de6L87-R111))

### Enhanced error handling:
* Added `DownloadHistoryOperationError` and refactored `ExportFileWriteError` to include operation context, improving error traceability. (`synology_drive_exporter/error.go`, [[1]](diffhunk://#diff-bb25c408d683322fcf2be74fabcf8399d3e322d2e5546c8625a688c8d8bb2eb3L3-R20) [[2]](diffhunk://#diff-bb25c408d683322fcf2be74fabcf8399d3e322d2e5546c8625a688c8d8bb2eb3L35-R58)
* Updated error handling in methods like `processItem` and `processDirectory` to log and count errors instead of returning them, ensuring uninterrupted processing of other items. (`synology_drive_exporter/exporter.go`, [[1]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L179-R229) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L261-L282)

### Transition from `log` to `fmt`:
* Replaced all `log` statements with `fmt` in the `cmd/export/main.go` file for consistent console output. (`cmd/export/main.go`, [[1]](diffhunk://#diff-ec447938ff5ceca7abc5424272d18e5a9c1cec2fdf3b0b45a42169d19e757de6L18-R23) [[2]](diffhunk://#diff-ec447938ff5ceca7abc5424272d18e5a9c1cec2fdf3b0b45a42169d19e757de6L60-R60) [[3]](diffhunk://#diff-ec447938ff5ceca7abc5424272d18e5a9c1cec2fdf3b0b45a42169d19e757de6L74-R74)

### Improved test coverage:
* Enhanced existing tests to validate `ExportStats` and ensure correct file counts and error handling. (`synology_drive_exporter/exporter_test.go`, [[1]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL147-R145) [[2]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL455-R453)
* Added a new test suite (`TestExporter_Counts`) to verify that the counters in `DownloadHistory` are incremented correctly for various scenarios, such as successful exports, skipped files, ignored files, and errors. (`synology_drive_exporter/exporter_test.go`, [synology_drive_exporter/exporter_test.goL514-R653](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL514-R653))

### Minor cleanup:
* Removed unused imports and redundant comments to improve code readability. (`synology_drive_exporter/exporter_test.go`, [synology_drive_exporter/exporter_test.goL10-L11](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL10-L11))