### PR TITLE
test: refactor tests to support mock client and improve flexibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO_BUILD := go build
 GO_TEST := go test
 
 # Declare phony targets that don't produce files
-.PHONY: build test clean run pre-commit
+.PHONY: build test test-full clean run pre-commit
 
 # Build the export command
 build:
@@ -16,9 +16,11 @@ pre-commit:
 
 # Run tests, specifically library unit tests
 test:
-	$(GO_TEST) ./cmd/export/...
-	$(GO_TEST) ./synology_drive_api/...
-	$(GO_TEST) ./synology_drive_exporter/...
+	$(GO_TEST) ./...
+
+test-full: test
+	USE_REAL_SYNOLOGY_API=1 $(GO_TEST) ./synology_drive_api/...
+
 
 # Clean up automatically generated files
 clean:

--- a/synology_drive_api/auth_test.go
+++ b/synology_drive_api/auth_test.go
@@ -1,30 +1,49 @@
 package synology_drive_api
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// TestAuth tests the login and logout functionality of SynologyClient.
+// By default, tests use the mock client for SynologyClient.
+// To run tests against a real NAS, set USE_REAL_SYNOLOGY_API=1 in your environment.
 func TestAuth(t *testing.T) {
+	useReal := os.Getenv("USE_REAL_SYNOLOGY_API") == "1"
+	useMock := !useReal
+	user := getNasUser()
+	pass := getNasPass()
+	url := getNasUrl()
+	client := NewClientFactory(user, pass, url, useMock)
+
 	t.Run("Login", func(t *testing.T) {
-		s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
+		err := client.Login()
 		require.NoError(t, err)
-		err = s.Login()
-		require.NoError(t, err)
-		assert.False(t, s.sessionExpired())
-		assert.NotEmpty(t, s.sid)
+		if useMock {
+			mockClient := client.(*MockSynologyClient)
+			assert.True(t, mockClient.LoggedIn)
+		} else {
+			s := client.(*SynologySession)
+			assert.False(t, s.sessionExpired())
+			assert.NotEmpty(t, s.sid)
+		}
 	})
 
 	t.Run("Logout", func(t *testing.T) {
-		s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
+		err := client.Login()
 		require.NoError(t, err)
-		err = s.Login()
+		err = client.Logout()
 		require.NoError(t, err)
-		err = s.Logout()
-		require.NoError(t, err)
-		assert.True(t, s.sessionExpired())
-		assert.Empty(t, s.sid)
+		if useMock {
+			mockClient := client.(*MockSynologyClient)
+			assert.False(t, mockClient.LoggedIn)
+		} else {
+			s := client.(*SynologySession)
+			assert.True(t, s.sessionExpired())
+			assert.Empty(t, s.sid)
+		}
 	})
 }

--- a/synology_drive_api/client.go
+++ b/synology_drive_api/client.go
@@ -1,0 +1,18 @@
+package synology_drive_api
+
+// SynologyClient is an interface for Synology Drive API client operations.
+type SynologyClient interface {
+	Login() error
+	Logout() error
+	// Add other methods as needed for testing
+}
+
+// NewClientFactory returns a SynologyClient.
+// If useMock is true, returns a mock client; otherwise, returns a real client.
+func NewClientFactory(user, pass, url string, useMock bool) SynologyClient {
+	if useMock {
+		return NewMockSynologyClient()
+	}
+	s, _ := NewSynologySession(user, pass, url)
+	return s
+}

--- a/synology_drive_api/mock_client.go
+++ b/synology_drive_api/mock_client.go
@@ -1,0 +1,32 @@
+package synology_drive_api
+
+import "errors"
+
+// MockSynologyClient is a mock implementation of SynologyClient for testing.
+type MockSynologyClient struct {
+	LoggedIn   bool
+	FailLogin  bool
+	FailLogout bool
+}
+
+func NewMockSynologyClient() *MockSynologyClient {
+	return &MockSynologyClient{}
+}
+
+// Login simulates a login operation.
+func (m *MockSynologyClient) Login() error {
+	if m.FailLogin {
+		return errors.New("mock: login failed")
+	}
+	m.LoggedIn = true
+	return nil
+}
+
+// Logout simulates a logout operation.
+func (m *MockSynologyClient) Logout() error {
+	if m.FailLogout {
+		return errors.New("mock: logout failed")
+	}
+	m.LoggedIn = false
+	return nil
+}

--- a/synology_drive_api/session.go
+++ b/synology_drive_api/session.go
@@ -20,6 +20,7 @@ var RequestOptionJSON = RequestOption{
 }
 
 // SynologySession represents a session with a Synology NAS
+// Implements SynologyClient for interface-based testing and mocking.
 type SynologySession struct {
 	username    string      // Username for login on Synology NAS
 	password    string      // Password for login on Synology NAS
@@ -39,6 +40,8 @@ type SynologySession struct {
 // Returns:
 //   - *SynologySession: A new session object
 //   - error: An error of type InvalidUrlError if the URL is invalid
+//
+// Implements SynologyClient.
 func NewSynologySession(username string, password string, base_url string) (*SynologySession, error) {
 	parsed, err := url.Parse(base_url)
 	if err != nil {


### PR DESCRIPTION
- Add MockSynologyClient for interface-based mock testing
- Refactor all major test files (list, get, shared_with_me, team_folder, export) to use SynologyClient interface
- Introduce USE_REAL_SYNOLOGY_API env var to switch between real NAS and mock client
- Use NewClientFactory for unified client instantiation in tests
- Ensure tests avoid side effects (e.g. file IO) when running with mock