### PR TITLE
feat: add mock server for testing and make it default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ test:
 	$(GO_TEST) ./synology_drive_api/...
 	$(GO_TEST) ./synology_drive_exporter/...
 
+test-full: test
+	USE_REAL_SYNOLOGY=1 $(GO_TEST) ./synology_drive_api/...
+
 # Clean up automatically generated files
 clean:
 	$(RM) bin/export out

--- a/synology_drive_api/api_test.go
+++ b/synology_drive_api/api_test.go
@@ -1,11 +1,114 @@
 package synology_drive_api
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 )
 
+// TestMain sets up a mock Synology NAS server by default.
+// If USE_REAL_SYNOLOGY is set, tests will run against a real NAS device.
+func TestMain(m *testing.M) {
+	if os.Getenv("USE_REAL_SYNOLOGY") == "" {
+		// Default: use mock
+		mockServer := httptest.NewServer(http.HandlerFunc(mockSynologyHandler))
+		defer mockServer.Close()
+		os.Setenv("SYNOLOGY_NAS_URL", mockServer.URL)
+		os.Setenv("SYNOLOGY_NAS_USER", "mock-user")
+		os.Setenv("SYNOLOGY_NAS_PASS", "mock-pass")
+	}
+	os.Exit(m.Run())
+}
+
+// mockSynologyHandler handles requests to the mock Synology NAS API.
+
+// mockLoggedIn tracks login state for the mock Synology NAS server.
+var mockLoggedIn bool
+
+// ResetMockLogin resets the mock login state to 'not logged in'.
+// Call this at the start of each test to avoid state leakage between tests.
+func ResetMockLogin() {
+	mockLoggedIn = false
+}
+
+func mockSynologyHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("[MOCK] %s %s\n", r.Method, r.URL.String())
+	switch r.URL.Path {
+	case "/webapi/auth.cgi":
+		method := r.URL.Query().Get("method")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch method {
+		case "login":
+			mockLoggedIn = true
+			w.Write([]byte(`{"success": true, "data": {"sid": "mock-sid"}}`))
+		case "logout":
+			mockLoggedIn = false
+			w.Write([]byte(`{"success": true}`))
+		default:
+			w.Write([]byte(`{"success": false, "error": {"code": 100}}`))
+		}
+	case "/webapi/entry.cgi":
+		method := r.URL.Query().Get("method")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch method {
+		case "get":
+			if !mockLoggedIn {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"success": false, "error": {"code": 119, "errors": {"line": 0, "message": "not logged in"}}}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			resp := map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"file_id":      "882614125167948399",
+					"name":         "planning.osheet",
+					"type":         "file",
+					"content_type": "document",
+					"size":         720,
+					"owner":        map[string]interface{}{"display_name": "backup", "name": "backup", "uid": 1029},
+					"starred":      false,
+					"shared":       false,
+					"path":         "/planning.osheet",
+					"display_path": "/mydrive/planning.osheet",
+					"raw":          "dummyrawdata",
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		default:
+			w.WriteHeader(http.StatusOK)
+			resp := map[string]interface{}{
+				"success": true,
+				"data":    map[string]interface{}{},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}
+	default:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"success": true}`))
+	}
+}
+
+// getEnvOrPanic returns environment variables for test credentials and URL.
+// By default, returns mock values unless USE_REAL_SYNOLOGY is set.
 func getEnvOrPanic(key string) string {
+	if os.Getenv("USE_REAL_SYNOLOGY") == "" {
+		switch key {
+		case "SYNOLOGY_NAS_USER":
+			return "mock-user"
+		case "SYNOLOGY_NAS_PASS":
+			return "mock-pass"
+		case "SYNOLOGY_NAS_URL":
+			return os.Getenv("SYNOLOGY_NAS_URL")
+		}
+	}
 	if value, exists := os.LookupEnv(key); !exists {
 		panic(key + " is not set")
 	} else {

--- a/synology_drive_api/auth_test.go
+++ b/synology_drive_api/auth_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAuth(t *testing.T) {
+	ResetMockLogin()
 	t.Run("Login", func(t *testing.T) {
 		s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
 		require.NoError(t, err)

--- a/synology_drive_api/export_test.go
+++ b/synology_drive_api/export_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestExport(t *testing.T) {
+	ResetMockLogin()
 	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
 	require.NoError(t, err)
 

--- a/synology_drive_api/get_test.go
+++ b/synology_drive_api/get_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestGet(t *testing.T) {
+	ResetMockLogin()
 	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
 	require.NoError(t, err)
 

--- a/synology_drive_api/list_test.go
+++ b/synology_drive_api/list_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestList(t *testing.T) {
+	ResetMockLogin()
 	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
 	require.NoError(t, err)
 	err = s.Login()

--- a/synology_drive_api/shared_with_me_test.go
+++ b/synology_drive_api/shared_with_me_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestSharedWithMe(t *testing.T) {
+	ResetMockLogin()
 	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
 	require.NoError(t, err)
 	err = s.Login()

--- a/synology_drive_api/team_folder_test.go
+++ b/synology_drive_api/team_folder_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestTeamFolder(t *testing.T) {
+	ResetMockLogin()
 	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
 	require.NoError(t, err)
 	err = s.Login()


### PR DESCRIPTION
- Added mock Synology NAS server for testing
- Made tests use mock server by default
- Added `USE_REAL_SYNOLOGY` flag for real NAS testing
- Added `make test-full` target for real NAS testing
- Added [ResetMockLogin()](cci:1://file:///Users/issei/git/go-synology-office-exporter/synology_drive_api/api_test.go:30:0-34:1) to prevent test interference