### PR TITLE
feat(exporter): improve download history status handling and add tests

### DIFF
--- a/synology_drive_exporter/download_history.go
+++ b/synology_drive_exporter/download_history.go
@@ -48,9 +48,6 @@ type DownloadHistory struct {
 // ErrHistoryItemNotFound is returned when the specified item does not exist in the history.
 var ErrHistoryItemNotFound = fmt.Errorf("download history item not found")
 
-// ErrHistoryItemAlreadyExists is returned when trying to add an item that already exists.
-var ErrHistoryItemAlreadyExists = fmt.Errorf("download history item already exists")
-
 // ErrHistoryInvalidStatus is returned when the item's status does not match the expected state.
 var ErrHistoryInvalidStatus = fmt.Errorf("download history item status is invalid")
 

--- a/synology_drive_exporter/download_history.go
+++ b/synology_drive_exporter/download_history.go
@@ -224,7 +224,7 @@ func (d *DownloadHistory) Load() error {
 	return d.loadFromReader(file)
 }
 
-// saveToWriter writes DownloadItems to JSON, including their Status field.
+// saveToWriter writes DownloadItems to JSON.
 func (d *DownloadHistory) saveToWriter(w io.Writer) error {
 	header := jsonHeader{
 		Version: HISTORY_VERSION,
@@ -258,8 +258,6 @@ func (d *DownloadHistory) saveToWriter(w io.Writer) error {
 	return nil
 }
 
-// Save writes the download history to the JSON file specified during initialization.
-// It returns a DownloadHistoryFileError if the file cannot be created or written to.
 // Save writes the download history to the JSON file specified during initialization.
 // It returns a DownloadHistoryFileError if the file cannot be created or written to.
 func (d *DownloadHistory) Save() error {

--- a/synology_drive_exporter/download_history.go
+++ b/synology_drive_exporter/download_history.go
@@ -27,12 +27,6 @@ func (c *counter) Get() int {
 	return c.count
 }
 
-// TestMakeKey generates a key for the given display path for testing purposes.
-// This is a test helper function and should only be used in tests.
-func TestMakeKey(displayPath string) string {
-	return strings.TrimPrefix(filepath.Clean(synd.GetExportFileName(displayPath)), "/")
-}
-
 // ExportStats holds the statistics of the export operation.
 type ExportStats struct {
 	Downloaded int // Number of successfully downloaded files

--- a/synology_drive_exporter/download_history.go
+++ b/synology_drive_exporter/download_history.go
@@ -45,6 +45,53 @@ type DownloadHistory struct {
 	ErrorCount    counter
 }
 
+// ErrHistoryItemNotFound is returned when the specified item does not exist in the history.
+var ErrHistoryItemNotFound = fmt.Errorf("download history item not found")
+
+// ErrHistoryItemAlreadyExists is returned when trying to add an item that already exists.
+var ErrHistoryItemAlreadyExists = fmt.Errorf("download history item already exists")
+
+// ErrHistoryInvalidStatus is returned when the item's status does not match the expected state.
+var ErrHistoryInvalidStatus = fmt.Errorf("download history item status is invalid")
+
+// SetItem sets or updates a DownloadItem for the given location in the download history.
+// This method should be used instead of direct access to the Items field from outside this struct.
+func (d *DownloadHistory) SetItem(location string, item DownloadItem) {
+	d.Items[location] = item
+}
+
+// MarkSkipped sets the status of an existing item to 'skipped' if its current status is 'loaded'.
+// Returns an error if the item does not exist or its status is not 'loaded'.
+func (d *DownloadHistory) MarkSkipped(location string) error {
+	item, ok := d.Items[location]
+	if !ok {
+		return ErrHistoryItemNotFound
+	}
+	if item.DownloadStatus != StatusLoaded {
+		return ErrHistoryInvalidStatus
+	}
+	item.DownloadStatus = StatusSkipped
+	d.Items[location] = item
+	return nil
+}
+
+// SetDownloaded adds a new item with status 'downloaded' if it does not exist, or updates an existing item
+// to 'downloaded' if its current status is 'loaded'. Returns an error if the item exists and its status is not 'loaded'.
+func (d *DownloadHistory) SetDownloaded(location string, item DownloadItem) error {
+	existing, ok := d.Items[location]
+	if ok {
+		if existing.DownloadStatus != StatusLoaded {
+			return ErrHistoryInvalidStatus
+		}
+		item.DownloadStatus = StatusDownloaded
+		d.Items[location] = item
+		return nil
+	}
+	item.DownloadStatus = StatusDownloaded
+	d.Items[location] = item
+	return nil
+}
+
 // GetStats returns the current export statistics.
 func (d *DownloadHistory) GetStats() ExportStats {
 	return ExportStats{
@@ -61,6 +108,7 @@ type jsonHeader struct {
 	Created string `json:"created"`
 }
 
+// jsonDownloadItem is used for marshaling/unmarshaling DownloadItem to/from JSON.
 type jsonDownloadItem struct {
 	Location     string        `json:"location"`
 	FileID       synd.FileID   `json:"file_id"`
@@ -73,10 +121,21 @@ type jsonDownloadHistory struct {
 	Items  []jsonDownloadItem `json:"items"`
 }
 
+// DownloadStatus represents the state of a DownloadItem (enum-like string type).
+type DownloadStatus string
+
+const (
+	StatusLoaded     DownloadStatus = "loaded"
+	StatusDownloaded DownloadStatus = "downloaded"
+	StatusSkipped    DownloadStatus = "skipped"
+)
+
+// DownloadItem holds information about a downloaded or tracked file, including its status.
 type DownloadItem struct {
-	FileID       synd.FileID
-	Hash         synd.FileHash
-	DownloadTime time.Time
+	FileID         synd.FileID
+	Hash           synd.FileHash
+	DownloadTime   time.Time
+	DownloadStatus DownloadStatus
 }
 
 /**
@@ -114,6 +173,7 @@ func (hdr *jsonHeader) validate() error {
 	return nil
 }
 
+// loadFromReader loads DownloadItems from JSON and sets Status to "loaded" if not present.
 func (d *DownloadHistory) loadFromReader(r io.Reader) error {
 	content, err := io.ReadAll(r)
 	if err != nil {
@@ -138,12 +198,15 @@ func (d *DownloadHistory) loadFromReader(r io.Reader) error {
 		if _, exists := d.Items[item.Location]; exists {
 			return DownloadHistoryParseError(fmt.Sprintf("duplicate location: %s", item.Location))
 		}
+		// Always initialize Status as StatusLoaded on load
 		d.Items[item.Location] = DownloadItem{
-			FileID:       item.FileID,
-			Hash:         item.Hash,
-			DownloadTime: downloadTime,
+			FileID:         item.FileID,
+			Hash:           item.Hash,
+			DownloadTime:   downloadTime,
+			DownloadStatus: StatusLoaded,
 		}
 	}
+
 	return nil
 }
 
@@ -164,6 +227,7 @@ func (d *DownloadHistory) Load() error {
 	return d.loadFromReader(file)
 }
 
+// saveToWriter writes DownloadItems to JSON, including their Status field.
 func (d *DownloadHistory) saveToWriter(w io.Writer) error {
 	header := jsonHeader{
 		Version: HISTORY_VERSION,
@@ -195,7 +259,6 @@ func (d *DownloadHistory) saveToWriter(w io.Writer) error {
 		return DownloadHistoryFileWriteError(err.Error())
 	}
 	return nil
-
 }
 
 // Save writes the download history to the JSON file specified during initialization.

--- a/synology_drive_exporter/download_history.go
+++ b/synology_drive_exporter/download_history.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	synd "github.com/isseis/go-synology-office-exporter/synology_drive_api"
@@ -24,6 +25,12 @@ func (c *counter) Increment() {
 
 func (c *counter) Get() int {
 	return c.count
+}
+
+// TestMakeKey generates a key for the given display path for testing purposes.
+// This is a test helper function and should only be used in tests.
+func TestMakeKey(displayPath string) string {
+	return strings.TrimPrefix(filepath.Clean(synd.GetExportFileName(displayPath)), "/")
 }
 
 // ExportStats holds the statistics of the export operation.
@@ -97,6 +104,14 @@ func (d *DownloadHistory) GetStats() ExportStats {
 		Ignored:    d.IgnoredCount.Get(),
 		Errors:     d.ErrorCount.Get(),
 	}
+}
+
+// GetItemByDisplayPath looks up a DownloadItem by its display path.
+// It returns the item and true if found, or false if not found.
+func (d *DownloadHistory) GetItemByDisplayPath(displayPath string) (DownloadItem, bool) {
+	key := strings.TrimPrefix(filepath.Clean(synd.GetExportFileName(displayPath)), "/")
+	item, exists := d.Items[key]
+	return item, exists
 }
 
 type jsonHeader struct {

--- a/synology_drive_exporter/download_history_test.go
+++ b/synology_drive_exporter/download_history_test.go
@@ -14,6 +14,71 @@ import (
 
 // TestNewDownloadHistory verifies that NewDownloadHistory correctly validates filenames
 // and returns appropriate errors for invalid filenames.
+func TestDownloadHistoryStatusMethods(t *testing.T) {
+	baseTime := time.Now().Truncate(time.Second)
+	itemLoaded := DownloadItem{
+		FileID:         "id1",
+		Hash:           "hash1",
+		DownloadTime:   baseTime,
+		DownloadStatus: StatusLoaded,
+	}
+	itemOther := DownloadItem{
+		FileID:         "id2",
+		Hash:           "hash2",
+		DownloadTime:   baseTime,
+		DownloadStatus: StatusDownloaded,
+	}
+
+	t.Run("MarkSkippedIfLoaded - success", func(t *testing.T) {
+		h, _ := NewDownloadHistory("dummy.json")
+		h.Items["file1"] = itemLoaded
+		err := h.MarkSkipped("file1")
+		assert.NoError(t, err)
+		assert.Equal(t, StatusSkipped, h.Items["file1"].DownloadStatus)
+	})
+	t.Run("MarkSkippedIfLoaded - not found", func(t *testing.T) {
+		h, _ := NewDownloadHistory("dummy.json")
+		err := h.MarkSkipped("notfound")
+		assert.ErrorIs(t, err, ErrHistoryItemNotFound)
+	})
+	t.Run("MarkSkippedIfLoaded - wrong status", func(t *testing.T) {
+		h, _ := NewDownloadHistory("dummy.json")
+		h.Items["file1"] = itemOther
+		err := h.MarkSkipped("file1")
+		assert.ErrorIs(t, err, ErrHistoryInvalidStatus)
+	})
+
+	t.Run("SetDownloaded - update loaded", func(t *testing.T) {
+		h, _ := NewDownloadHistory("dummy.json")
+		h.Items["file2"] = itemLoaded
+		newItem := itemLoaded
+		newItem.FileID = "id3"
+		newItem.Hash = "hash3"
+		newItem.DownloadTime = baseTime.Add(time.Hour)
+		err := h.SetDownloaded("file2", newItem)
+		assert.NoError(t, err)
+		assert.Equal(t, StatusDownloaded, h.Items["file2"].DownloadStatus)
+		assert.Equal(t, "id3", string(h.Items["file2"].FileID))
+		assert.Equal(t, "hash3", string(h.Items["file2"].Hash))
+		assert.Equal(t, baseTime.Add(time.Hour), h.Items["file2"].DownloadTime)
+	})
+	t.Run("SetDownloaded - add new", func(t *testing.T) {
+		h, _ := NewDownloadHistory("dummy.json")
+		item := itemLoaded
+		item.DownloadStatus = StatusLoaded
+		err := h.SetDownloaded("file3", item)
+		assert.NoError(t, err)
+		assert.Equal(t, StatusDownloaded, h.Items["file3"].DownloadStatus)
+	})
+	t.Run("SetDownloaded - error on wrong status", func(t *testing.T) {
+		h, _ := NewDownloadHistory("dummy.json")
+		h.Items["file2"] = itemOther
+		newItem := itemOther
+		err := h.SetDownloaded("file2", newItem)
+		assert.ErrorIs(t, err, ErrHistoryInvalidStatus)
+	})
+}
+
 func TestNewDownloadHistory(t *testing.T) {
 	t.Run("Valid filename", func(t *testing.T) {
 		validNames := []string{

--- a/synology_drive_exporter/download_history_test.go
+++ b/synology_drive_exporter/download_history_test.go
@@ -29,19 +29,19 @@ func TestDownloadHistoryStatusMethods(t *testing.T) {
 		DownloadStatus: StatusDownloaded,
 	}
 
-	t.Run("MarkSkippedIfLoaded - success", func(t *testing.T) {
+	t.Run("MarkSkipped - success", func(t *testing.T) {
 		h, _ := NewDownloadHistory("dummy.json")
 		h.Items["file1"] = itemLoaded
 		err := h.MarkSkipped("file1")
 		assert.NoError(t, err)
 		assert.Equal(t, StatusSkipped, h.Items["file1"].DownloadStatus)
 	})
-	t.Run("MarkSkippedIfLoaded - not found", func(t *testing.T) {
+	t.Run("MarkSkipped - not found", func(t *testing.T) {
 		h, _ := NewDownloadHistory("dummy.json")
 		err := h.MarkSkipped("notfound")
 		assert.ErrorIs(t, err, ErrHistoryItemNotFound)
 	})
-	t.Run("MarkSkippedIfLoaded - wrong status", func(t *testing.T) {
+	t.Run("MarkSkipped - wrong status", func(t *testing.T) {
 		h, _ := NewDownloadHistory("dummy.json")
 		h.Items["file1"] = itemOther
 		err := h.MarkSkipped("file1")

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"maps"
+
 	synd "github.com/isseis/go-synology-office-exporter/synology_drive_api"
 )
 
@@ -525,9 +527,7 @@ func newTestDownloadHistory(items map[string]DownloadItem) *DownloadHistory {
 	history := &DownloadHistory{
 		Items: make(map[string]DownloadItem),
 	}
-	for k, v := range items {
-		history.Items[k] = v
-	}
+	maps.Copy(history.Items, items)
 	return history
 }
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the `DownloadHistory` functionality in the `synology_drive_exporter` package, focusing on better tracking of download statuses, enforcing state transitions, and improving test coverage. The changes include the addition of new status management methods, updates to the `DownloadItem` structure, and integration of these updates into the file processing logic.

### Enhancements to `DownloadHistory` functionality:
* Added new methods to `DownloadHistory` for managing download statuses: `SetItem`, `MarkSkipped`, `SetDownloaded`, and `GetItemByDisplayPath`. These methods enforce state transitions and encapsulate logic for modifying the `Items` map. [[1]](diffhunk://#diff-9d16800cf6ebb850b308317702830e377f3433fbae6f32edc225e3719280d959R49-R92) [[2]](diffhunk://#diff-9d16800cf6ebb850b308317702830e377f3433fbae6f32edc225e3719280d959R103-R117)
* Introduced a `DownloadStatus` type with three possible states: `loaded`, `downloaded`, and `skipped`. The `DownloadItem` structure was updated to include this status field.
* Ensured that items loaded from JSON are initialized with the `StatusLoaded` state during deserialization.

### Integration into file processing logic:
* Updated the `processFile` method in `exporter.go` to use the new `DownloadHistory` methods for status transitions, ensuring proper handling of skipped and downloaded files. [[1]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047R213-R217) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L224-R245)
* Enhanced comments in `processFile` and `processItem` to document the intended behavior of status transitions. [[1]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L191-R200) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047R273-R277)

### Testing improvements:
* Added unit tests for the new `DownloadHistory` methods, including scenarios for valid and invalid state transitions.
* Extended integration tests to validate the coexistence of `loaded`, `downloaded`, and `skipped` statuses in the export workflow.
* Refactored test utilities, such as `newTestDownloadHistory` and `makeTestKey`, to simplify test setup and key generation for `DownloadHistory`. [[1]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL524-R537) [[2]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL540-R549)

These changes improve the robustness of the download tracking system, enforce stricter state management, and ensure comprehensive test coverage for the new functionality.