### PR TITLE
Refactor: Improve DownloadHistory encapsulation and removed dangerous SetItems method

### DIFF
--- a/download_history/download_history.go
+++ b/download_history/download_history.go
@@ -47,11 +47,6 @@ type DownloadHistory struct {
 	ErrorCount    counter
 }
 
-// SetItems replaces the internal items map (for testing only).
-func (d *DownloadHistory) SetItems(m map[string]DownloadItem) {
-	d.items = m
-}
-
 // MakeHistoryKey generates a key for download history from a display path.
 // This replicates the logic previously used in synology_drive_exporter.MakeHistoryKey.
 func MakeHistoryKey(displayPath string) string {

--- a/download_history/download_history.go
+++ b/download_history/download_history.go
@@ -36,14 +36,20 @@ type ExportStats struct {
 }
 
 // DownloadHistory manages the download state and statistics.
+// DownloadHistory manages the download state and statistics.
 type DownloadHistory struct {
-	Items map[string]DownloadItem
+	items map[string]DownloadItem // items holds the download history, private for encapsulation
 	path  string
 
 	DownloadCount counter
 	SkippedCount  counter
 	IgnoredCount  counter
 	ErrorCount    counter
+}
+
+// SetItems replaces the internal items map (for testing only).
+func (d *DownloadHistory) SetItems(m map[string]DownloadItem) {
+	d.items = m
 }
 
 // MakeHistoryKey generates a key for download history from a display path.
@@ -61,7 +67,7 @@ var ErrHistoryInvalidStatus = fmt.Errorf("download history item status is invali
 // MarkSkipped sets the status of an existing item to 'skipped'.
 // Returns an error if the item does not exist or if the item's status is not 'loaded'.
 func (d *DownloadHistory) MarkSkipped(location string) error {
-	item, ok := d.Items[location]
+	item, ok := d.items[location]
 	if !ok {
 		return ErrHistoryItemNotFound
 	}
@@ -69,24 +75,24 @@ func (d *DownloadHistory) MarkSkipped(location string) error {
 		return ErrHistoryInvalidStatus
 	}
 	item.DownloadStatus = StatusSkipped
-	d.Items[location] = item
+	d.items[location] = item
 	return nil
 }
 
 // SetDownloaded adds a new item with status 'downloaded' if it does not exist, or updates an existing item
 // to 'downloaded' if its current status is 'loaded'. Returns an error if the item exists and its status is not 'loaded'.
 func (d *DownloadHistory) SetDownloaded(location string, item DownloadItem) error {
-	existing, ok := d.Items[location]
+	existing, ok := d.items[location]
 	if ok {
 		if existing.DownloadStatus != StatusLoaded {
 			return ErrHistoryInvalidStatus
 		}
 		item.DownloadStatus = StatusDownloaded
-		d.Items[location] = item
+		d.items[location] = item
 		return nil
 	}
 	item.DownloadStatus = StatusDownloaded
-	d.Items[location] = item
+	d.items[location] = item
 	return nil
 }
 
@@ -103,7 +109,7 @@ func (d *DownloadHistory) GetStats() ExportStats {
 // GetItem looks up a DownloadItem by its key.
 // It returns the item and true if found, or false if not found.
 func (d *DownloadHistory) GetItem(key string) (DownloadItem, bool) {
-	item, exists := d.Items[key]
+	item, exists := d.items[key]
 	return item, exists
 }
 
@@ -161,7 +167,7 @@ func NewDownloadHistory(path string) (*DownloadHistory, error) {
 	}
 
 	history := &DownloadHistory{
-		Items: make(map[string]DownloadItem),
+		items: make(map[string]DownloadItem),
 		path:  path,
 	}
 	return history, nil
@@ -201,11 +207,11 @@ func (d *DownloadHistory) loadFromReader(r io.Reader) error {
 			return fmt.Errorf("failed to parse download time: %s", err.Error())
 		}
 		// Prevent duplicate locations in the history map.
-		if _, exists := d.Items[item.Location]; exists {
+		if _, exists := d.items[item.Location]; exists {
 			return fmt.Errorf("duplicate location: %s", item.Location)
 		}
 		// Set DownloadStatus to StatusLoaded on load to reflect state from file.
-		d.Items[item.Location] = DownloadItem{
+		d.items[item.Location] = DownloadItem{
 			FileID:         item.FileID,
 			Hash:           item.Hash,
 			DownloadTime:   downloadTime,
@@ -241,8 +247,8 @@ func (d *DownloadHistory) saveToWriter(w io.Writer) error {
 		Created: time.Now().Format(time.RFC3339),
 	}
 
-	items := make([]jsonDownloadItem, 0, len(d.Items))
-	for location, item := range d.Items {
+	items := make([]jsonDownloadItem, 0, len(d.items))
+	for location, item := range d.items {
 		items = append(items, jsonDownloadItem{
 			Location:     location,
 			FileID:       item.FileID,

--- a/download_history/download_history_test_helper.go
+++ b/download_history/download_history_test_helper.go
@@ -5,7 +5,16 @@ package download_history
 //
 // Note: This function is included in all builds unless this file is restricted to test builds via a build tag.
 func NewDownloadHistoryForTest(items map[string]DownloadItem) *DownloadHistory {
-	dh := &DownloadHistory{}
-	dh.items = items
+	if items == nil {
+		items = make(map[string]DownloadItem)
+	}
+	dh := &DownloadHistory{
+		items:         items,
+		path:          "test-history.json",
+		DownloadCount: counter{},
+		SkippedCount:  counter{},
+		IgnoredCount:  counter{},
+		ErrorCount:    counter{},
+	}
 	return dh
 }

--- a/download_history/download_history_test_helper.go
+++ b/download_history/download_history_test_helper.go
@@ -1,0 +1,11 @@
+package download_history
+
+// NewDownloadHistoryForTest creates a DownloadHistory instance initialized with the given items map.
+// This is intended for test code convenience.
+//
+// Note: This function is included in all builds unless this file is restricted to test builds via a build tag.
+func NewDownloadHistoryForTest(items map[string]DownloadItem) *DownloadHistory {
+	dh := &DownloadHistory{}
+	dh.items = items
+	return dh
+}

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -578,9 +578,9 @@ func TestExporter_Counts(t *testing.T) {
 		mockFS := NewMockFileSystem()
 		history, err := download_history.NewDownloadHistory("test_history.json")
 		require.NoError(t, err)
-		history.Items = map[string]download_history.DownloadItem{
+		history.SetItems(map[string]download_history.DownloadItem{
 			cleanPath: {FileID: fileID, Hash: fileHash},
-		}
+		})
 		item := ExportItem{
 			Type:        synd.ObjectTypeFile,
 			FileID:      fileID,
@@ -699,9 +699,9 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 		path := MakeHistoryKey(item.DisplayPath)
 		history, err := download_history.NewDownloadHistory("test_history.json")
 		require.NoError(t, err)
-		history.Items = map[string]download_history.DownloadItem{
+		history.SetItems(map[string]download_history.DownloadItem{
 			path: {FileID: "file1", Hash: "hash1", DownloadStatus: download_history.StatusLoaded, DownloadTime: initialTime},
-		}
+		})
 		session := &MockSynologySession{
 			ExportFunc: func(fid synd.FileID) (*synd.ExportResponse, error) {
 				return &synd.ExportResponse{Content: []byte("file content")}, nil
@@ -710,7 +710,6 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 		mockFS := NewMockFileSystem()
 		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processFile(item, history)
-		t.Logf("[DEBUG] after MarkSkipped: history.Items[%q].DownloadStatus = %v", path, history.Items[path].DownloadStatus)
 
 		// Inline getHistoryItemByDisplayPath logic (was: dlItem := getHistoryItemByDisplayPath(...))
 		dlItem, exists := history.GetItem(download_history.MakeHistoryKey(item.DisplayPath))
@@ -731,11 +730,11 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 		item3 := ExportItem{Type: synd.ObjectTypeFile, FileID: "file3", DisplayPath: "/doc/test3.odoc", Hash: "hash3"}     // only in history
 		history, err := download_history.NewDownloadHistory("test_history.json")
 		require.NoError(t, err)
-		history.Items = map[string]download_history.DownloadItem{
+		history.SetItems(map[string]download_history.DownloadItem{
 			MakeHistoryKey(item1.DisplayPath): {FileID: "file1", Hash: "hash1", DownloadStatus: download_history.StatusLoaded},
 			MakeHistoryKey(item2.DisplayPath): {FileID: "file2", Hash: "hash2-old", DownloadStatus: download_history.StatusLoaded},
 			MakeHistoryKey(item3.DisplayPath): {FileID: "file3", Hash: "hash3", DownloadStatus: download_history.StatusLoaded},
-		}
+		})
 		session := &MockSynologySession{
 			ExportFunc: func(fid synd.FileID) (*synd.ExportResponse, error) {
 				return &synd.ExportResponse{Content: []byte("file content")}, nil
@@ -825,7 +824,7 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 			}
 			history, err := download_history.NewDownloadHistory("test_history.json")
 			require.NoError(t, err)
-			history.Items = tc.history
+			history.SetItems(tc.history)
 			item := ExportItem{
 				Type:        synd.ObjectTypeFile,
 				FileID:      fileID,

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -576,9 +576,8 @@ func TestExporter_Counts(t *testing.T) {
 			},
 		}
 		mockFS := NewMockFileSystem()
-		history, err := download_history.NewDownloadHistory("test_history.json")
-		require.NoError(t, err)
-		history.SetItems(map[string]download_history.DownloadItem{
+		// Use test helper to create DownloadHistory with initial items for testing
+		history := download_history.NewDownloadHistoryForTest(map[string]download_history.DownloadItem{
 			cleanPath: {FileID: fileID, Hash: fileHash},
 		})
 		item := ExportItem{
@@ -697,9 +696,8 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 		}
 		initialTime := time.Date(2024, 5, 18, 8, 0, 0, 0, time.UTC)
 		path := MakeHistoryKey(item.DisplayPath)
-		history, err := download_history.NewDownloadHistory("test_history.json")
-		require.NoError(t, err)
-		history.SetItems(map[string]download_history.DownloadItem{
+		// Use test helper to create DownloadHistory with initial items for testing
+		history := download_history.NewDownloadHistoryForTest(map[string]download_history.DownloadItem{
 			path: {FileID: "file1", Hash: "hash1", DownloadStatus: download_history.StatusLoaded, DownloadTime: initialTime},
 		})
 		session := &MockSynologySession{
@@ -728,9 +726,8 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 		item1 := ExportItem{Type: synd.ObjectTypeFile, FileID: "file1", DisplayPath: "/doc/test1.odoc", Hash: "hash1"}     // hash unchanged
 		item2 := ExportItem{Type: synd.ObjectTypeFile, FileID: "file2", DisplayPath: "/doc/test2.odoc", Hash: "hash2-new"} // hash changed
 		item3 := ExportItem{Type: synd.ObjectTypeFile, FileID: "file3", DisplayPath: "/doc/test3.odoc", Hash: "hash3"}     // only in history
-		history, err := download_history.NewDownloadHistory("test_history.json")
-		require.NoError(t, err)
-		history.SetItems(map[string]download_history.DownloadItem{
+		// Use test helper to create DownloadHistory with initial items for testing
+		history := download_history.NewDownloadHistoryForTest(map[string]download_history.DownloadItem{
 			MakeHistoryKey(item1.DisplayPath): {FileID: "file1", Hash: "hash1", DownloadStatus: download_history.StatusLoaded},
 			MakeHistoryKey(item2.DisplayPath): {FileID: "file2", Hash: "hash2-old", DownloadStatus: download_history.StatusLoaded},
 			MakeHistoryKey(item3.DisplayPath): {FileID: "file3", Hash: "hash3", DownloadStatus: download_history.StatusLoaded},
@@ -822,9 +819,7 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 				writeCalled = true
 				return nil
 			}
-			history, err := download_history.NewDownloadHistory("test_history.json")
-			require.NoError(t, err)
-			history.SetItems(tc.history)
+			history := download_history.NewDownloadHistoryForTest(tc.history)
 			item := ExportItem{
 				Type:        synd.ObjectTypeFile,
 				FileID:      fileID,


### PR DESCRIPTION
This pull request refactors the `DownloadHistory` class to improve encapsulation by making the `Items` map private (`items`) and introduces a test helper function to simplify test setup. The changes also update all relevant methods, tests, and usages to accommodate this encapsulation.

### Refactoring for Encapsulation:
* Changed `Items` to `items` in `DownloadHistory` to make it private, ensuring better encapsulation. All methods and functions accessing `Items` were updated accordingly. (`download_history/download_history.go`: [[1]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60R38-R41) [[2]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L64-R90) [[3]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L106-R107) [[4]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L164-R165) [[5]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L204-R209) [[6]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L244-R246)

### Test Improvements:
* Introduced `NewDownloadHistoryForTest` to create `DownloadHistory` instances with predefined items for testing purposes, reducing boilerplate in test setup. (`download_history/download_history_test_helper.go`: [download_history/download_history_test_helper.goR1-R20](diffhunk://#diff-e4534a5a0a1a85dc936f582a0175cde17e793e4c26f132cfa8ce8ab81b6fbac5R1-R20))
* Updated all test cases to use the new `NewDownloadHistoryForTest` function instead of directly manipulating `Items`. (`download_history/download_history_test.go`: [[1]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L21-R29) [[2]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L56-R90) [[3]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L120-R111) [[4]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L170-R161) [[5]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L315-R310) [[6]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L343-R334) [[7]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L357-R351) [[8]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L386-R382) [[9]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L405-R393) [[10]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L419-R416) [[11]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L449-R449) [[12]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L482-R473)

### Updates in Dependent Modules:
* Updated test cases in `synology_drive_exporter` to use the new test helper for creating `DownloadHistory` instances. (`synology_drive_exporter/exporter_test.go`: [[1]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL579-R582) [[2]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL700-R702) [[3]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL713) [[4]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL732-R734) [[5]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL826-R822)