### PR TITLE
feat: Add file cleanup for obsolete exported files

### DIFF
--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/joho/godotenv"
 
-	"github.com/isseis/go-synology-office-exporter/download_history"
 	syndexp "github.com/isseis/go-synology-office-exporter/synology_drive_exporter"
 )
 
@@ -149,7 +148,7 @@ func main() {
 
 	// Run the export for each specified source
 	for _, source := range sources {
-		var stats download_history.ExportStats
+		var stats syndexp.ExportStats
 		var err error
 
 		switch source {
@@ -169,10 +168,10 @@ func main() {
 			continue
 		}
 
-		fmt.Printf("[%s] Downloaded: %d, Skipped: %d, Ignored: %d, Errors: %d\n",
-			source, stats.Downloaded, stats.Skipped, stats.Ignored, stats.Errors)
+		fmt.Printf("[%s] Downloaded: %d, Skipped: %d, Ignored: %d, Removed:	 %d, DownloadErrs: %d, RemoveErrs: %d\n",
+			source, stats.Downloaded, stats.Skipped, stats.Ignored, stats.Removed, stats.DownloadErrs, stats.RemoveErrs)
 
-		if stats.Errors > 0 {
+		if stats.TotalErrs() > 0 {
 			exitCode = 1
 		}
 	}

--- a/download_history/download_history.go
+++ b/download_history/download_history.go
@@ -36,7 +36,7 @@ type ExportStats struct {
 
 // DownloadHistory manages the download state and statistics.
 type DownloadHistory struct {
-	items map[string]DownloadItem // items holds the download history, private for encapsulation
+	items map[string]DownloadItem
 	path  string
 
 	DownloadCount counter
@@ -273,4 +273,16 @@ func (d *DownloadHistory) Save() error {
 	}
 	defer file.Close()
 	return d.saveToWriter(file)
+}
+
+// GetObsoleteItems returns a slice of file paths that are marked as "loaded" in the history.
+// These represent files that exist in history but were not found in the current export.
+func (d *DownloadHistory) GetObsoleteItems() []string {
+	var obsolete []string
+	for path, item := range d.items {
+		if item.DownloadStatus == StatusLoaded {
+			obsolete = append(obsolete, path)
+		}
+	}
+	return obsolete
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `synology_drive_exporter` project by improving the handling of export statistics, adding support for obsolete file cleanup, and enhancing test coverage. The changes primarily focus on improving maintainability, adding new features, and ensuring robustness through comprehensive testing.

### Enhancements to Export Statistics
* Introduced a new `ExportStats` struct in `synology_drive_exporter/exporter.go` to track detailed export statistics, including counts for removed files, download errors, and removal errors. Added methods like `TotalErrs`, `IncrementRemoved`, and `String` for better usability.
* Updated all export-related methods to use the new `ExportStats` instead of the previous `download_history.ExportStats`. This improves encapsulation and simplifies the code. [[1]](diffhunk://#diff-ec447938ff5ceca7abc5424272d18e5a9c1cec2fdf3b0b45a42169d19e757de6L152-R151) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L83-R134) [[3]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L107-R150) [[4]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047R159-R199)

### Obsolete File Cleanup
* Added a `GetObsoleteItems` method in `download_history.go` to identify files marked as "loaded" but not found in the current export.
* Implemented `cleanupObsoleteFiles` in `synology_drive_exporter/exporter.go` to remove obsolete files, with support for a dry-run mode and error handling.
* Introduced a `removeFile` helper method to handle file removal operations with logging and dry-run support.

### Test Coverage Enhancements
* Added unit tests for the new `ExportStats` functionality, ensuring accurate error counting and string representation.
* Introduced tests for `removeFile` and `cleanupObsoleteFiles`, covering scenarios like normal cleanup, dry-run mode, and skipping cleanup on errors.

### Codebase Simplification
* Removed the unused `download_history.ExportStats` dependency from `cmd/export/main.go` and replaced it with `synology_drive_exporter.ExportStats`. [[1]](diffhunk://#diff-ec447938ff5ceca7abc5424272d18e5a9c1cec2fdf3b0b45a42169d19e757de6L13) [[2]](diffhunk://#diff-ec447938ff5ceca7abc5424272d18e5a9c1cec2fdf3b0b45a42169d19e757de6L152-R151)
* Simplified the `DownloadHistory` struct by removing unnecessary comments for private fields.

### Logging and Debugging
* Added logging for file removal operations and cleanup decisions, improving traceability during export operations.

These changes collectively enhance the functionality, maintainability, and reliability of the `synology_drive_exporter` project.