### PR TITLE
Add dry_run feature

### DIFF
--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -135,7 +135,7 @@ func main() {
 	}
 
 	fmt.Printf("Synology Office Exporter v%s\n", Version)
-	exporter, err := syndexp.NewExporter(user, pass, url, downloadDir, *dryRunFlag)
+	exporter, err := syndexp.NewExporter(user, pass, url, downloadDir, syndexp.WithDryRun(*dryRunFlag))
 	if err != nil {
 		log.Fatalf("Failed to create exporter: %v", err)
 	}

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -82,6 +82,8 @@ func main() {
 	urlFlag := flag.String("url", "", "Synology NAS URL")
 	downloadDirFlag := flag.String("output", "", "Directory to save downloaded files")
 	sourcesFlag := flag.String("sources", "mydrive,teamfolder,shared", "Comma-separated list of sources to export (mydrive,teamfolder,shared)")
+	// dry_run: If true, performs a dry run (no files are downloaded or written, only statistics are shown)
+	dryRunFlag := flag.Bool("dry_run", false, "If set, perform a dry run (no file downloads, only show statistics)")
 	flag.Parse()
 
 	// Fallback to environment variables if flags are not provided
@@ -133,7 +135,7 @@ func main() {
 	}
 
 	fmt.Printf("Synology Office Exporter v%s\n", Version)
-	exporter, err := syndexp.NewExporter(user, pass, url, downloadDir)
+	exporter, err := syndexp.NewExporter(user, pass, url, downloadDir, *dryRunFlag)
 	if err != nil {
 		log.Fatalf("Failed to create exporter: %v", err)
 	}

--- a/synology_drive_exporter/exporter.go
+++ b/synology_drive_exporter/exporter.go
@@ -346,8 +346,6 @@ func (e *Exporter) processItem(item ExportItem, history *download_history.Downlo
 	}
 }
 
-// removeFile removes the specified file from the filesystem
-// In DryRun mode, it only logs the operation without actually removing the file
 // removeFile removes the specified file from the filesystem.
 // In DryRun mode, it only logs the operation without actually removing the file.
 func (e *Exporter) removeFile(path string) error {

--- a/synology_drive_exporter/exporter.go
+++ b/synology_drive_exporter/exporter.go
@@ -87,18 +87,25 @@ type SessionInterface interface {
 }
 
 // Exporter handles exporting files from Synology Drive, maintaining download history and file system abstraction.
+// Exporter handles exporting files from Synology Drive, maintaining download history and file system abstraction.
 type Exporter struct {
 	session     SessionInterface
 	downloadDir string // Directory where downloaded files will be saved
 	fs          FileSystemOperations
 
-	// When DryRun is true, no actual file operations will be performed
-	// Only log messages and statistics will be updated
-	DryRun bool
+	// dryRun controls whether file operations are performed. Immutable after construction.
+	dryRun bool
+}
+
+// IsDryRun returns true if the exporter is in dry-run mode.
+func (e *Exporter) IsDryRun() bool {
+	return e.dryRun
 }
 
 // NewExporter constructs an Exporter with a real Synology session and the specified download directory. If downloadDir is empty, the current directory is used.
-func NewExporter(username string, password string, base_url string, downloadDir string) (*Exporter, error) {
+// NewExporter constructs an Exporter with a real Synology session and the specified download directory. If downloadDir is empty, the current directory is used.
+// The dryRun parameter controls whether file operations are performed.
+func NewExporter(username string, password string, base_url string, downloadDir string, dryRun bool) (*Exporter, error) {
 	session, err := synd.NewSynologySession(username, password, base_url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %w", err)
@@ -106,16 +113,19 @@ func NewExporter(username string, password string, base_url string, downloadDir 
 	if err = session.Login(); err != nil {
 		return nil, fmt.Errorf("failed to login: %w", err)
 	}
-	exporter := NewExporterWithDependencies(session, downloadDir, &DefaultFileSystem{})
+	exporter := NewExporterWithDependencies(session, downloadDir, &DefaultFileSystem{}, dryRun)
 	return exporter, nil
 }
 
 // NewExporterWithDependencies constructs an Exporter with injected dependencies for session, download directory, and file system. Intended for testing and advanced use.
-func NewExporterWithDependencies(session SessionInterface, downloadDir string, fs FileSystemOperations) *Exporter {
+// NewExporterWithDependencies constructs an Exporter with injected dependencies for session, download directory, and file system. Intended for testing and advanced use.
+// The dryRun parameter controls whether file operations are performed.
+func NewExporterWithDependencies(session SessionInterface, downloadDir string, fs FileSystemOperations, dryRun bool) *Exporter {
 	return &Exporter{
 		session:     session,
 		downloadDir: downloadDir,
 		fs:          fs,
+		dryRun:      dryRun,
 	}
 }
 
@@ -223,6 +233,8 @@ func (e *Exporter) processDirectory(item ExportItem, history *download_history.D
 }
 
 // processFile exports a single convertible file and updates download history. Handles export, skip, and error logic.
+// processFile exports a single convertible file and updates download history. Handles export, skip, and error logic.
+// In dry-run mode, no file operations are performed; only statistics are updated.
 func (e *Exporter) processFile(item ExportItem, history *download_history.DownloadHistory) {
 	exportName := synd.GetExportFileName(item.DisplayPath)
 	if exportName == "" {
@@ -241,6 +253,21 @@ func (e *Exporter) processFile(item ExportItem, history *download_history.Downlo
 		if err != nil {
 			fmt.Printf("Warning: could not mark as skipped: %v\n", err)
 		}
+		return
+	}
+	if e.IsDryRun() {
+		fmt.Printf("[DRY RUN] Would export file: %s\n", exportName)
+		// Simulate successful export for statistics only
+		newItem := download_history.DownloadItem{
+			FileID:       item.FileID,
+			Hash:         item.Hash,
+			DownloadTime: time.Now(),
+		}
+		errHistory := history.SetDownloaded(localPath, newItem)
+		if errHistory != nil {
+			fmt.Printf("Warning: could not update download history: %v\n", errHistory)
+		}
+		history.DownloadCount.Increment()
 		return
 	}
 	fmt.Printf("Exporting file: %s\n", exportName)
@@ -306,8 +333,10 @@ func (e *Exporter) processItem(item ExportItem, history *download_history.Downlo
 
 // removeFile removes the specified file from the filesystem
 // In DryRun mode, it only logs the operation without actually removing the file
+// removeFile removes the specified file from the filesystem.
+// In DryRun mode, it only logs the operation without actually removing the file.
 func (e *Exporter) removeFile(path string) error {
-	if e.DryRun {
+	if e.dryRun {
 		log.Printf("[DRY RUN] Would remove file: %s", path)
 		return nil
 	}
@@ -335,12 +364,10 @@ func (e *Exporter) cleanupObsoleteFiles(history *download_history.DownloadHistor
 	obsoletePaths := history.GetObsoleteItems()
 	for _, path := range obsoletePaths {
 		if err := e.removeFile(path); err != nil {
-			if !e.DryRun { // Only count errors in non-dry run mode
-				stats.IncrementRemoveErrs()
-			}
+			stats.IncrementRemoveErrs() // Always count errors
 			log.Printf("Error removing file: %v", err)
-		} else if !e.DryRun { // Only count successful removals in non-dry run mode
-			stats.IncrementRemoved()
+		} else {
+			stats.IncrementRemoved() // Always count successful removals
 		}
 	}
 }

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -447,7 +447,7 @@ func TestExporterExportMyDrive(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			exporter := NewExporterWithDependencies(mockSession, dir, mockFS, false)
+			exporter := NewExporterWithDependencies(mockSession, dir, mockFS)
 			defer os.RemoveAll(dir)
 
 			// Run the test
@@ -850,7 +850,7 @@ func TestExporter_Counts(t *testing.T) {
 			DisplayPath: "/doc/test1.odoc",
 			Hash:        fileHash,
 		}
-		exporter := NewExporterWithDependencies(session, "", mockFS, false)
+		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processItem(item, history)
 		if got := history.DownloadCount.Get(); got != 1 {
 			t.Errorf("DownloadCount = %d, want 1", got)
@@ -874,7 +874,7 @@ func TestExporter_Counts(t *testing.T) {
 			DisplayPath: "/doc/test1.odoc",
 			Hash:        fileHash,
 		}
-		exporter := NewExporterWithDependencies(session, "", mockFS, false)
+		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processItem(item, history)
 		if got := history.SkippedCount.Get(); got != 1 {
 			t.Errorf("SkippedCount = %d, want 1", got)
@@ -892,7 +892,7 @@ func TestExporter_Counts(t *testing.T) {
 			DisplayPath: ignoredPath,
 			Hash:        fileHash,
 		}
-		exporter := NewExporterWithDependencies(session, "", mockFS, false)
+		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processItem(item, history)
 		if got := history.IgnoredCount.Get(); got != 1 {
 			t.Errorf("IgnoredCount = %d, want 1", got)
@@ -914,7 +914,7 @@ func TestExporter_Counts(t *testing.T) {
 			DisplayPath: "/doc/test2.odoc",
 			Hash:        fileHash2,
 		}
-		exporter := NewExporterWithDependencies(session, "", mockFS, false)
+		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processItem(item, history)
 		if got := history.ErrorCount.Get(); got != 1 {
 			t.Errorf("ErrorCount = %d, want 1", got)
@@ -939,7 +939,7 @@ func TestExporter_Counts(t *testing.T) {
 			DisplayPath: "/doc/test2.odoc",
 			Hash:        fileHash2,
 		}
-		exporter := NewExporterWithDependencies(session, "", mockFS, false)
+		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processItem(item, history)
 		if got := history.ErrorCount.Get(); got != 1 {
 			t.Errorf("ErrorCount = %d, want 1", got)
@@ -965,7 +965,7 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 			DisplayPath: "/doc/test1.odoc",
 			Hash:        "hash1",
 		}
-		exporter := NewExporterWithDependencies(session, "", mockFS, false)
+		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processFile(item, history)
 		// Retrieve the history item by display path.
 		dlItem, exists := history.GetItem(makeLocalFileName(item.DisplayPath))
@@ -994,7 +994,7 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 			},
 		}
 		mockFS := NewMockFileSystem()
-		exporter := NewExporterWithDependencies(session, "", mockFS, false)
+		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processFile(item, history)
 
 		// Inline getHistoryItemByDisplayPath logic (was: dlItem := getHistoryItemByDisplayPath(...))
@@ -1026,7 +1026,7 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 			},
 		}
 		mockFS := NewMockFileSystem()
-		exporter := NewExporterWithDependencies(session, "", mockFS, false)
+		exporter := NewExporterWithDependencies(session, "", mockFS)
 		exporter.processFile(item1, history) // should become skipped
 		exporter.processFile(item2, history) // should become downloaded
 		// item3 not processed, remains loaded
@@ -1114,7 +1114,7 @@ func TestExportItem_HistoryAndHash(t *testing.T) {
 				DisplayPath: displayPath,
 				Hash:        tc.itemHash,
 			}
-			exporter := NewExporterWithDependencies(session, "", mockFS, false)
+			exporter := NewExporterWithDependencies(session, "", mockFS)
 			exporter.processItem(item, history)
 			if writeCalled != tc.expectWrite {
 				t.Errorf("expected write: %v, got: %v", tc.expectWrite, writeCalled)


### PR DESCRIPTION
This pull request introduces a "dry-run" mode to the Synology Drive Exporter, allowing users to simulate operations without performing actual file downloads or modifications. The changes include updates to the `Exporter` class to support this feature, modifications to the main application logic to expose the new mode via a command-line flag, and adjustments to related tests to validate the behavior.

Fix #60 

### New Feature: Dry-Run Mode

* Added a `dry_run` flag to the command-line interface in `cmd/export/main.go`, enabling users to activate dry-run mode.
* Modified the `NewExporter` and `NewExporterWithDependencies` constructors in `synology_drive_exporter/exporter.go` to accept an optional `WithDryRun` function, which configures the `Exporter` to operate in dry-run mode. [[1]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047R89-R144) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047R251-R252)
* Implemented the `IsDryRun` method in the `Exporter` class to check if dry-run mode is active.

### Updates to File Processing Logic

* Enhanced the `processFile` method to simulate file exports in dry-run mode by logging operations and updating statistics without performing actual file downloads.
* Updated the `removeFile` method to log file removals instead of deleting files when in dry-run mode.
* Adjusted the `cleanupObsoleteFiles` method to always count successful removals and errors, even in dry-run mode.

### Test Enhancements

* Modified unit tests in `synology_drive_exporter/exporter_test.go` to validate the behavior of the `Exporter` in dry-run mode, including ensuring that no files are actually removed while operations are logged and statistics are updated correctly. [[1]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL626-R626) [[2]](diffhunk://#diff-e552b9aa888f96e32b722669bd87c7df72e8e56b899522c9bbe977dc5339547bL747-R757)