### PR TITLE
Issei/api pagination

### DIFF
--- a/synology_drive_api/constants.go
+++ b/synology_drive_api/constants.go
@@ -3,6 +3,8 @@ package synology_drive_api
 // Default constants for the Synology Drive API
 const (
 	// DefaultMaxPageSize is the default maximum number of items that can be
-	// requested in a single List API call.
+	// requested in a single API call.
 	DefaultMaxPageSize = 1000
+	// DefaultPageSize is the default number of items to request per page when making paginated API calls.
+	DefaultPageSize = 1000
 )

--- a/synology_drive_api/constants.go
+++ b/synology_drive_api/constants.go
@@ -1,0 +1,8 @@
+package synology_drive_api
+
+// Default constants for the Synology Drive API
+const (
+	// DefaultMaxPageSize is the default maximum number of items that can be
+	// requested in a single List API call.
+	DefaultMaxPageSize = 1000
+)

--- a/synology_drive_api/list.go
+++ b/synology_drive_api/list.go
@@ -25,7 +25,7 @@ type ListResponse struct {
 //   - offset: The starting position (must be >= 0)
 //   - limit: Maximum number of items to return (must be > 0 and <= session's maxPageSize)
 //   - Returns a ListResponse with items and total count, or an error if the operation fails.
-func (s *SynologySession) List(fileID FileID, offset, limit int) (*ListResponse, error) {
+func (s *SynologySession) List(fileID FileID, offset, limit int64) (*ListResponse, error) {
 	if offset < 0 {
 		return nil, fmt.Errorf("offset must be >= 0, got %d", offset)
 	}
@@ -41,8 +41,8 @@ func (s *SynologySession) List(fileID FileID, offset, limit int) (*ListResponse,
 			"filter":         "{}",
 			"sort_direction": "asc",
 			"sort_by":        "owner",
-			"offset":         strconv.Itoa(offset),
-			"limit":          strconv.Itoa(limit),
+			"offset":         strconv.FormatInt(offset, 10),
+			"limit":          strconv.FormatInt(limit, 10),
 			"path":           fileID.toAPIParam(),
 		},
 	}

--- a/synology_drive_api/list_test.go
+++ b/synology_drive_api/list_test.go
@@ -10,8 +10,8 @@ import (
 func TestList(t *testing.T) {
 	tests := []struct {
 		name          string
-		offset        int
-		limit         int
+		offset        int64
+		limit         int64
 		expectedError string
 	}{
 		{"valid request", 0, 100, ""},

--- a/synology_drive_api/list_test.go
+++ b/synology_drive_api/list_test.go
@@ -8,18 +8,40 @@ import (
 )
 
 func TestList(t *testing.T) {
-	ResetMockLogin()
-	s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
-	require.NoError(t, err)
-	err = s.Login()
-	require.NoError(t, err)
-	resp, err := s.List(MyDrive)
-	require.NoError(t, err)
+	tests := []struct {
+		name          string
+		offset        int
+		limit         int
+		expectedError string
+	}{
+		{"valid request", 0, 100, ""},
+		{"negative offset", -1, 100, "offset must be >= 0"},
+		{"zero limit", 0, 0, "limit must be between 1 and 1000"},
+		{"limit too large", 0, 1001, "limit must be between 1 and 1000"},
+	}
 
-	// t.Log("Response:", string(resp.raw))
-	for _, item := range resp.Items {
-		assert.NotEmpty(t, item.FileID)
-		assert.NotEmpty(t, item.Name)
-		assert.NotEmpty(t, item.Path)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetMockLogin()
+			s, err := NewSynologySession(getNasUser(), getNasPass(), getNasUrl())
+			require.NoError(t, err)
+			err = s.Login()
+			require.NoError(t, err)
+
+			resp, err := s.List(MyDrive, tt.offset, tt.limit)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			for _, item := range resp.Items {
+				assert.NotEmpty(t, item.FileID)
+				assert.NotEmpty(t, item.Name)
+				assert.NotEmpty(t, item.Path)
+			}
+		})
 	}
 }

--- a/synology_drive_api/session.go
+++ b/synology_drive_api/session.go
@@ -24,7 +24,7 @@ type SessionOption func(*SynologySession)
 
 // WithMaxPageSize sets the maximum number of items that can be requested in a single List call.
 // If not set, DefaultMaxPageSize will be used.
-func WithMaxPageSize(maxPageSize int) SessionOption {
+func WithMaxPageSize(maxPageSize int64) SessionOption {
 	return func(s *SynologySession) {
 		s.maxPageSize = maxPageSize
 	}
@@ -38,7 +38,7 @@ type SynologySession struct {
 	scheme      string      // URL scheme (http or https)
 	sid         SessionID   // Session ID (set after login)
 	http_client http.Client // HTTP client with cookie support
-	maxPageSize int         // Maximum number of items per page for List operations
+	maxPageSize int64       // Maximum number of items per page for List operations
 }
 
 // NewSynologySession creates a new Synology API session with the provided credentials and base URL.

--- a/synology_drive_api/shared_with_me.go
+++ b/synology_drive_api/shared_with_me.go
@@ -31,7 +31,7 @@ type SharedWithMeResponse struct {
 //   - limit: Maximum number of items to return (1-DefaultMaxPageSize)
 //   - Returns a SharedWithMeResponse containing the list of shared items and their details,
 //     or an error if the API request fails.
-func (s *SynologySession) SharedWithMe(offset, limit int) (*SharedWithMeResponse, error) {
+func (s *SynologySession) SharedWithMe(offset, limit int64) (*SharedWithMeResponse, error) {
 	// Validate pagination parameters
 	if offset < 0 {
 		return nil, fmt.Errorf("offset must be >= 0, got %d", offset)
@@ -48,8 +48,8 @@ func (s *SynologySession) SharedWithMe(offset, limit int) (*SharedWithMeResponse
 			"filter":         "{}",
 			"sort_direction": "asc",
 			"sort_by":        "owner",
-			"offset":         strconv.Itoa(offset),
-			"limit":          strconv.Itoa(limit),
+			"offset":         strconv.FormatInt(offset, 10),
+			"limit":          strconv.FormatInt(limit, 10),
 		},
 	}
 

--- a/synology_drive_api/shared_with_me.go
+++ b/synology_drive_api/shared_with_me.go
@@ -2,6 +2,7 @@ package synology_drive_api
 
 import (
 	"fmt"
+	"strconv"
 )
 
 // jsonResponseItem represents a file or folder item in a Synology Drive listing or shared-with-me API response
@@ -25,7 +26,20 @@ type SharedWithMeResponse struct {
 	raw   []byte
 }
 
-func (s *SynologySession) SharedWithMe() (*SharedWithMeResponse, error) {
+// SharedWithMe retrieves a paginated list of files and folders shared with the user.
+//   - offset: The starting position (0-based)
+//   - limit: Maximum number of items to return (1-DefaultMaxPageSize)
+//   - Returns a SharedWithMeResponse containing the list of shared items and their details,
+//     or an error if the API request fails.
+func (s *SynologySession) SharedWithMe(offset, limit int) (*SharedWithMeResponse, error) {
+	// Validate pagination parameters
+	if offset < 0 {
+		return nil, fmt.Errorf("offset must be >= 0, got %d", offset)
+	}
+	if limit <= 0 || limit > DefaultMaxPageSize {
+		return nil, fmt.Errorf("limit must be between 1 and %d, got %d", DefaultMaxPageSize, limit)
+	}
+
 	req := apiRequest{
 		api:     APINameSynologyDriveFiles,
 		method:  "shared_with_me",
@@ -34,8 +48,8 @@ func (s *SynologySession) SharedWithMe() (*SharedWithMeResponse, error) {
 			"filter":         "{}",
 			"sort_direction": "asc",
 			"sort_by":        "owner",
-			"offset":         "0",
-			"limit":          "1000",
+			"offset":         strconv.Itoa(offset),
+			"limit":          strconv.Itoa(limit),
 		},
 	}
 

--- a/synology_drive_api/shared_with_me_test.go
+++ b/synology_drive_api/shared_with_me_test.go
@@ -14,7 +14,7 @@ func TestSharedWithMe(t *testing.T) {
 	err = s.Login()
 	require.NoError(t, err)
 
-	resp, err := s.SharedWithMe()
+	resp, err := s.SharedWithMe(0, DefaultMaxPageSize)
 	require.NoError(t, err)
 	// t.Log("Response:", string(resp.raw))
 	assert.GreaterOrEqual(t, resp.Total, int64(0))

--- a/synology_drive_api/team_folder.go
+++ b/synology_drive_api/team_folder.go
@@ -21,7 +21,7 @@ type jsonTeamFolderListResponseV1 struct {
 	synologyAPIResponse
 	Data struct {
 		Items []jsonTeamFolderListItemV1 `json:"items"`
-		Total int                        `json:"total"`
+		Total int64                      `json:"total"`
 	} `json:"data"`
 }
 
@@ -39,7 +39,7 @@ type TeamFolderResponseItem struct {
 // TeamFolderResponse represents the response from listing team folders
 type TeamFolderResponse struct {
 	Items []*TeamFolderResponseItem
-	Total int
+	Total int64
 	raw   []byte // Stores the original raw JSON response
 }
 
@@ -65,7 +65,7 @@ func (j *jsonTeamFolderListItemV1) toTeamFolderResponseItem() *TeamFolderRespons
 //   - limit: Maximum number of items to return (1-DefaultMaxPageSize)
 //   - Returns a TeamFolderResponse containing the list of team folders and their details,
 //     or an error if the API request fails.
-func (s *SynologySession) TeamFolder(offset, limit int) (*TeamFolderResponse, error) {
+func (s *SynologySession) TeamFolder(offset, limit int64) (*TeamFolderResponse, error) {
 	// Validate pagination parameters
 	if offset < 0 {
 		return nil, fmt.Errorf("offset must be >= 0, got %d", offset)
@@ -82,8 +82,8 @@ func (s *SynologySession) TeamFolder(offset, limit int) (*TeamFolderResponse, er
 			"filter":         "{}",
 			"sort_direction": "asc",
 			"sort_by":        "owner",
-			"offset":         strconv.Itoa(offset),
-			"limit":          strconv.Itoa(limit),
+			"offset":         strconv.FormatInt(offset, 10),
+			"limit":          strconv.FormatInt(limit, 10),
 		},
 	}
 

--- a/synology_drive_api/team_folder.go
+++ b/synology_drive_api/team_folder.go
@@ -1,5 +1,10 @@
 package synology_drive_api
 
+import (
+	"fmt"
+	"strconv"
+)
+
 // jsonTeamFolderListItemV1 represents the JSON structure of a team folder list item
 type jsonTeamFolderListItemV1 struct {
 	Capabilities     jsonCapabilities `json:"capabilities"`
@@ -55,7 +60,20 @@ func (j *jsonTeamFolderListItemV1) toTeamFolderResponseItem() *TeamFolderRespons
 // TeamFolder retrieves a list of team folders from the Synology Drive API.
 // It returns a TeamFolderResponse containing the list of team folders and their details,
 // or an error if the API request fails.
-func (s *SynologySession) TeamFolder() (*TeamFolderResponse, error) {
+// TeamFolder retrieves a paginated list of team folders from the Synology Drive API.
+//   - offset: The starting position (0-based)
+//   - limit: Maximum number of items to return (1-DefaultMaxPageSize)
+//   - Returns a TeamFolderResponse containing the list of team folders and their details,
+//     or an error if the API request fails.
+func (s *SynologySession) TeamFolder(offset, limit int) (*TeamFolderResponse, error) {
+	// Validate pagination parameters
+	if offset < 0 {
+		return nil, fmt.Errorf("offset must be >= 0, got %d", offset)
+	}
+	if limit <= 0 || limit > DefaultMaxPageSize {
+		return nil, fmt.Errorf("limit must be between 1 and %d, got %d", DefaultMaxPageSize, limit)
+	}
+
 	req := apiRequest{
 		api:     APINameSynologyDriveTeamFolders,
 		method:  "list",
@@ -64,8 +82,8 @@ func (s *SynologySession) TeamFolder() (*TeamFolderResponse, error) {
 			"filter":         "{}",
 			"sort_direction": "asc",
 			"sort_by":        "owner",
-			"offset":         "0",
-			"limit":          "1000",
+			"offset":         strconv.Itoa(offset),
+			"limit":          strconv.Itoa(limit),
 		},
 	}
 

--- a/synology_drive_api/team_folder_test.go
+++ b/synology_drive_api/team_folder_test.go
@@ -13,7 +13,7 @@ func TestTeamFolder(t *testing.T) {
 	err = s.Login()
 	require.NoError(t, err)
 
-	resp, err := s.TeamFolder()
+	resp, err := s.TeamFolder(0, DefaultMaxPageSize)
 	require.NoError(t, err)
 	//t.Log("Response:", string(resp.raw))
 	for _, item := range resp.Items {

--- a/synology_drive_exporter/api_helper.go
+++ b/synology_drive_exporter/api_helper.go
@@ -1,0 +1,49 @@
+package synology_drive_exporter
+
+import (
+	"fmt"
+
+	synd "github.com/isseis/go-synology-office-exporter/synology_drive_api"
+)
+
+// SessionInterface abstracts Synology session operations for export and testability.
+type SessionInterface interface {
+	// List retrieves a paginated list of items from the specified root directory.
+	//   - rootDirID: The identifier of the folder to list
+	//   - offset: The starting position (0-based)
+	//   - limit: Maximum number of items to return (1-1000)
+	//   - Returns a ListResponse with items and total count, or an error if the operation fails.
+	List(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error)
+
+	// Export exports the specified file, performing format conversion if needed.
+	Export(fileID synd.FileID) (*synd.ExportResponse, error)
+
+	// TeamFolder retrieves team folders from the Synology Drive API.
+	TeamFolder() (*synd.TeamFolderResponse, error)
+
+	// SharedWithMe retrieves files shared with the user.
+	SharedWithMe() (*synd.SharedWithMeResponse, error)
+}
+
+// listAll retrieves all items from a directory by making multiple paginated requests.
+// This is a helper function that can be used by implementations of SessionInterface.
+func listAll(s SessionInterface, rootDirID synd.FileID) ([]*synd.ResponseItem, error) {
+	const pageSize = 1000
+	var allItems []*synd.ResponseItem
+
+	for offset := 0; ; offset += pageSize {
+		resp, err := s.List(rootDirID, offset, pageSize)
+		if err != nil {
+			return nil, fmt.Errorf("error listing items at offset %d: %w", offset, err)
+		}
+
+		allItems = append(allItems, resp.Items...)
+
+		// Stop if we've received all items or if the response is empty
+		if len(allItems) >= int(resp.Total) || len(resp.Items) == 0 {
+			break
+		}
+	}
+
+	return allItems, nil
+}

--- a/synology_drive_exporter/exporter.go
+++ b/synology_drive_exporter/exporter.go
@@ -138,7 +138,7 @@ func (e *Exporter) ExportMyDrive() (ExportStats, error) {
 
 // ExportTeamFolder exports convertible files from all team folders, using download history to avoid duplicates.
 func (e *Exporter) ExportTeamFolder() (ExportStats, error) {
-	teamFolders, err := listAllTeamFolders(e.session)
+	teamFolders, err := teamFoldersAll(e.session)
 	if err != nil {
 		return ExportStats{}, err
 	}
@@ -154,7 +154,7 @@ func (e *Exporter) ExportTeamFolder() (ExportStats, error) {
 
 // ExportSharedWithMe exports convertible files and directories shared with the user, using download history to avoid duplicates.
 func (e *Exporter) ExportSharedWithMe() (ExportStats, error) {
-	sharedItems, err := listAllSharedWithMe(e.session)
+	sharedItems, err := sharedWithMeAll(e.session)
 	if err != nil {
 		return ExportStats{}, err
 	}

--- a/synology_drive_exporter/exporter.go
+++ b/synology_drive_exporter/exporter.go
@@ -73,8 +73,12 @@ func (fs *DefaultFileSystem) CreateFile(filename string, data []byte, dirPerm os
 
 // SessionInterface abstracts Synology session operations for export and testability.
 type SessionInterface interface {
-	// List retrieves items from the specified root directory.
-	List(rootDirID synd.FileID) (*synd.ListResponse, error)
+	// List retrieves a paginated list of items from the specified root directory.
+	//   - rootDirID: The identifier of the folder to list
+	//   - offset: The starting position (0-based)
+	//   - limit: Maximum number of items to return (1-1000)
+	//   - Returns a ListResponse with items and total count, or an error if the operation fails.
+	List(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error)
 
 	// Export exports the specified file, performing format conversion if needed.
 	Export(fileID synd.FileID) (*synd.ExportResponse, error)
@@ -84,6 +88,29 @@ type SessionInterface interface {
 
 	// SharedWithMe retrieves files shared with the user.
 	SharedWithMe() (*synd.SharedWithMeResponse, error)
+}
+
+// listAll retrieves all items from a directory by making multiple paginated requests.
+// This is a helper function that can be used by implementations of SessionInterface.
+func listAll(s SessionInterface, rootDirID synd.FileID) ([]*synd.ResponseItem, error) {
+	const pageSize = 1000
+	var allItems []*synd.ResponseItem
+
+	for offset := 0; ; offset += pageSize {
+		resp, err := s.List(rootDirID, offset, pageSize)
+		if err != nil {
+			return nil, fmt.Errorf("error listing items at offset %d: %w", offset, err)
+		}
+
+		allItems = append(allItems, resp.Items...)
+
+		// Stop if we've received all items or if the response is empty
+		if len(allItems) >= int(resp.Total) || len(resp.Items) == 0 {
+			break
+		}
+	}
+
+	return allItems, nil
 }
 
 // Exporter handles exporting files from Synology Drive, maintaining download history and file system abstraction.
@@ -235,13 +262,14 @@ func (e *Exporter) ExportRootsWithHistory(
 
 // processDirectory recursively processes a directory and its subdirectories, exporting convertible files and recording errors in history.
 func (e *Exporter) processDirectory(item ExportItem, history *download_history.DownloadHistory) {
-	list, err := e.session.List(item.FileID)
+	// Use listAll to handle pagination automatically
+	items, err := listAll(e.session, item.FileID)
 	if err != nil {
 		fmt.Printf("Failed to list directory %s: %v\n", item.DisplayPath, err)
 		history.ErrorCount.Increment()
 		return
 	}
-	for _, child := range list.Items {
+	for _, child := range items {
 		e.processItem(toExportItem(child), history)
 	}
 }

--- a/synology_drive_exporter/exporter.go
+++ b/synology_drive_exporter/exporter.go
@@ -71,48 +71,6 @@ func (fs *DefaultFileSystem) CreateFile(filename string, data []byte, dirPerm os
 	return nil
 }
 
-// SessionInterface abstracts Synology session operations for export and testability.
-type SessionInterface interface {
-	// List retrieves a paginated list of items from the specified root directory.
-	//   - rootDirID: The identifier of the folder to list
-	//   - offset: The starting position (0-based)
-	//   - limit: Maximum number of items to return (1-1000)
-	//   - Returns a ListResponse with items and total count, or an error if the operation fails.
-	List(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error)
-
-	// Export exports the specified file, performing format conversion if needed.
-	Export(fileID synd.FileID) (*synd.ExportResponse, error)
-
-	// TeamFolder retrieves team folders from the Synology Drive API.
-	TeamFolder() (*synd.TeamFolderResponse, error)
-
-	// SharedWithMe retrieves files shared with the user.
-	SharedWithMe() (*synd.SharedWithMeResponse, error)
-}
-
-// listAll retrieves all items from a directory by making multiple paginated requests.
-// This is a helper function that can be used by implementations of SessionInterface.
-func listAll(s SessionInterface, rootDirID synd.FileID) ([]*synd.ResponseItem, error) {
-	const pageSize = 1000
-	var allItems []*synd.ResponseItem
-
-	for offset := 0; ; offset += pageSize {
-		resp, err := s.List(rootDirID, offset, pageSize)
-		if err != nil {
-			return nil, fmt.Errorf("error listing items at offset %d: %w", offset, err)
-		}
-
-		allItems = append(allItems, resp.Items...)
-
-		// Stop if we've received all items or if the response is empty
-		if len(allItems) >= int(resp.Total) || len(resp.Items) == 0 {
-			break
-		}
-	}
-
-	return allItems, nil
-}
-
 // Exporter handles exporting files from Synology Drive, maintaining download history and file system abstraction.
 type Exporter struct {
 	session     SessionInterface

--- a/synology_drive_exporter/exporter.go
+++ b/synology_drive_exporter/exporter.go
@@ -138,12 +138,12 @@ func (e *Exporter) ExportMyDrive() (ExportStats, error) {
 
 // ExportTeamFolder exports convertible files from all team folders, using download history to avoid duplicates.
 func (e *Exporter) ExportTeamFolder() (ExportStats, error) {
-	teamFolder, err := e.session.TeamFolder()
+	teamFolders, err := listAllTeamFolders(e.session)
 	if err != nil {
 		return ExportStats{}, err
 	}
 	var rootIDs []synd.FileID
-	for _, item := range teamFolder.Items {
+	for _, item := range teamFolders {
 		rootIDs = append(rootIDs, item.FileID)
 	}
 	return e.ExportRootsWithHistory(
@@ -154,12 +154,12 @@ func (e *Exporter) ExportTeamFolder() (ExportStats, error) {
 
 // ExportSharedWithMe exports convertible files and directories shared with the user, using download history to avoid duplicates.
 func (e *Exporter) ExportSharedWithMe() (ExportStats, error) {
-	sharedWithMe, err := e.session.SharedWithMe()
+	sharedItems, err := listAllSharedWithMe(e.session)
 	if err != nil {
 		return ExportStats{}, err
 	}
 	var exportItems []ExportItem
-	for _, item := range sharedWithMe.Items {
+	for _, item := range sharedItems {
 		exportItems = append(exportItems, toExportItem(item))
 	}
 	return e.exportItemsWithHistory(exportItems, "shared_with_me_history.json")

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -46,13 +46,13 @@ func (m *MockFileSystem) CreateFile(filename string, data []byte, dirPerm os.Fil
 }
 
 type MockSynologySession struct {
-	ListFunc         func(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error)
+	ListFunc         func(rootDirID synd.FileID, offset, limit int64) (*synd.ListResponse, error)
 	ExportFunc       func(fileID synd.FileID) (*synd.ExportResponse, error)
-	TeamFolderFunc   func(offset, limit int) (*synd.TeamFolderResponse, error)
-	SharedWithMeFunc func(offset, limit int) (*synd.SharedWithMeResponse, error)
+	TeamFolderFunc   func(offset, limit int64) (*synd.TeamFolderResponse, error)
+	SharedWithMeFunc func(offset, limit int64) (*synd.SharedWithMeResponse, error)
 }
 
-func (m *MockSynologySession) List(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error) {
+func (m *MockSynologySession) List(rootDirID synd.FileID, offset, limit int64) (*synd.ListResponse, error) {
 	if m.ListFunc == nil {
 		return nil, errors.New("ListFunc not set")
 	}
@@ -66,14 +66,14 @@ func (m *MockSynologySession) Export(fileID synd.FileID) (*synd.ExportResponse, 
 	return &synd.ExportResponse{}, nil
 }
 
-func (m *MockSynologySession) TeamFolder(offset, limit int) (*synd.TeamFolderResponse, error) {
+func (m *MockSynologySession) TeamFolder(offset, limit int64) (*synd.TeamFolderResponse, error) {
 	if m.TeamFolderFunc != nil {
 		return m.TeamFolderFunc(offset, limit)
 	}
 	return &synd.TeamFolderResponse{}, nil
 }
 
-func (m *MockSynologySession) SharedWithMe(offset, limit int) (*synd.SharedWithMeResponse, error) {
+func (m *MockSynologySession) SharedWithMe(offset, limit int64) (*synd.SharedWithMeResponse, error) {
 	if m.SharedWithMeFunc != nil {
 		return m.SharedWithMeFunc(offset, limit)
 	}
@@ -387,7 +387,7 @@ func TestExporterExportMyDrive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create mocks
 			mockSession := &MockSynologySession{
-				ListFunc: func(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error) {
+				ListFunc: func(rootDirID synd.FileID, offset, limit int64) (*synd.ListResponse, error) {
 					// Track that this directory was listed
 					if tt.trackedListCalls != nil {
 						tt.trackedListCalls[rootDirID] = true

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -48,8 +48,8 @@ func (m *MockFileSystem) CreateFile(filename string, data []byte, dirPerm os.Fil
 type MockSynologySession struct {
 	ListFunc         func(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error)
 	ExportFunc       func(fileID synd.FileID) (*synd.ExportResponse, error)
-	TeamFolderFunc   func() (*synd.TeamFolderResponse, error)
-	SharedWithMeFunc func() (*synd.SharedWithMeResponse, error)
+	TeamFolderFunc   func(offset, limit int) (*synd.TeamFolderResponse, error)
+	SharedWithMeFunc func(offset, limit int) (*synd.SharedWithMeResponse, error)
 }
 
 func (m *MockSynologySession) List(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error) {
@@ -66,16 +66,16 @@ func (m *MockSynologySession) Export(fileID synd.FileID) (*synd.ExportResponse, 
 	return &synd.ExportResponse{}, nil
 }
 
-func (m *MockSynologySession) TeamFolder() (*synd.TeamFolderResponse, error) {
+func (m *MockSynologySession) TeamFolder(offset, limit int) (*synd.TeamFolderResponse, error) {
 	if m.TeamFolderFunc != nil {
-		return m.TeamFolderFunc()
+		return m.TeamFolderFunc(offset, limit)
 	}
 	return &synd.TeamFolderResponse{}, nil
 }
 
-func (m *MockSynologySession) SharedWithMe() (*synd.SharedWithMeResponse, error) {
+func (m *MockSynologySession) SharedWithMe(offset, limit int) (*synd.SharedWithMeResponse, error) {
 	if m.SharedWithMeFunc != nil {
-		return m.SharedWithMeFunc()
+		return m.SharedWithMeFunc(offset, limit)
 	}
 	return &synd.SharedWithMeResponse{}, nil
 }

--- a/synology_drive_exporter/exporter_test.go
+++ b/synology_drive_exporter/exporter_test.go
@@ -46,17 +46,17 @@ func (m *MockFileSystem) CreateFile(filename string, data []byte, dirPerm os.Fil
 }
 
 type MockSynologySession struct {
-	ListFunc         func(rootDirID synd.FileID) (*synd.ListResponse, error)
+	ListFunc         func(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error)
 	ExportFunc       func(fileID synd.FileID) (*synd.ExportResponse, error)
 	TeamFolderFunc   func() (*synd.TeamFolderResponse, error)
 	SharedWithMeFunc func() (*synd.SharedWithMeResponse, error)
 }
 
-func (m *MockSynologySession) List(rootDirID synd.FileID) (*synd.ListResponse, error) {
-	if m.ListFunc != nil {
-		return m.ListFunc(rootDirID)
+func (m *MockSynologySession) List(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error) {
+	if m.ListFunc == nil {
+		return nil, errors.New("ListFunc not set")
 	}
-	return &synd.ListResponse{}, nil
+	return m.ListFunc(rootDirID, offset, limit)
 }
 
 func (m *MockSynologySession) Export(fileID synd.FileID) (*synd.ExportResponse, error) {
@@ -387,7 +387,7 @@ func TestExporterExportMyDrive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create mocks
 			mockSession := &MockSynologySession{
-				ListFunc: func(rootDirID synd.FileID) (*synd.ListResponse, error) {
+				ListFunc: func(rootDirID synd.FileID, offset, limit int) (*synd.ListResponse, error) {
 					// Track that this directory was listed
 					if tt.trackedListCalls != nil {
 						tt.trackedListCalls[rootDirID] = true


### PR DESCRIPTION
This pull request introduces significant enhancements to the Synology Drive API integration, focusing on adding pagination support for listing operations, improving testability, and refactoring the exporter to handle paginated data. The changes include updates to API methods, the introduction of pagination utilities, and modifications to the exporter logic to leverage these utilities.

Fix #32 

### Pagination Support and API Enhancements:
* Added pagination parameters (`offset` and `limit`) to the `List`, `SharedWithMe`, and `TeamFolder` methods, along with validation for these parameters. This ensures more efficient data retrieval by supporting paginated responses (`synology_drive_api/list.go`, `synology_drive_api/shared_with_me.go`, `synology_drive_api/team_folder.go`). [[1]](diffhunk://#diff-d3320d1d7a69617d59babb1d49dcd317d329c1fa0f6dd51ee78ec74d2351f22dL22-R35) [[2]](diffhunk://#diff-f525985ebd54734b7f973c6093272f1deaa6f241650871f5552f07df42b1b323L28-R42) [[3]](diffhunk://#diff-ea26c2b6e4b8c716ebb9ac647cd0a3a6eca8bfaa7e4b9e52f840a105dfad196fL58-R76)
* Introduced `DefaultMaxPageSize` and `DefaultPageSize` constants to define default pagination limits, and added a `maxPageSize` field to `SynologySession` with a configurable option (`WithMaxPageSize`). This allows dynamic configuration of pagination limits (`synology_drive_api/constants.go`, `synology_drive_api/session.go`). [[1]](diffhunk://#diff-9d63260fcde926ec556d2cacc7f79a162d28259045cebc0e9084aa753e83af61R1-R10) [[2]](diffhunk://#diff-181aa75004dd197b2038710b3902c3445b269064b702b82d4e5a6834e7b7535cR22-R32) [[3]](diffhunk://#diff-181aa75004dd197b2038710b3902c3445b269064b702b82d4e5a6834e7b7535cR41-R76)

### Exporter Refactoring:
* Refactored the exporter to use new pagination utilities (`listAll`, `teamFoldersAll`, `sharedWithMeAll`) for handling paginated data. This improves scalability and simplifies the logic for processing large datasets (`synology_drive_exporter/api_helper.go`, `synology_drive_exporter/exporter.go`). [[1]](diffhunk://#diff-9fc09fbab23eac3eaa1d2cc0348db96a1560083c025707b729254b4eace0eca8R1-R86) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L238-R230) [[3]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L156-R146)

### Test Enhancements:
* Updated unit tests for `List`, `SharedWithMe`, and `TeamFolder` to include test cases for pagination validation (e.g., negative offsets, limits exceeding the maximum). This ensures the robustness of the new pagination logic (`synology_drive_api/list_test.go`, `synology_drive_api/shared_with_me_test.go`, `synology_drive_api/team_folder_test.go`). [[1]](diffhunk://#diff-737225822a18fa8b06273acd2174d343aac65c61547666f6a2f6cc309d12ae09R11-R46) [[2]](diffhunk://#diff-62c74fef5501fe81de46aea91d6d388ec31d5c5f4f8d959ac7ffe65ec1a539dfL17-R17) [[3]](diffhunk://#diff-53b5a77f56409755e3aa2569c9a0d1f9b69268a4a991d7984680e90bf5bbddf0L16-R16)
* Refactored the `MockSynologySession` in tests to support the updated method signatures with pagination parameters (`synology_drive_exporter/exporter_test.go`).

### Codebase Simplification:
* Removed redundant `SessionInterface` definition from `exporter.go` and consolidated it into `api_helper.go` for better organization and testability (`synology_drive_exporter/api_helper.go`, `synology_drive_exporter/exporter.go`). [[1]](diffhunk://#diff-9fc09fbab23eac3eaa1d2cc0348db96a1560083c025707b729254b4eace0eca8R1-R86) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047L74-L88)
* Updated data types for `Total` fields in API responses (e.g., `int` to `int64`) to ensure consistency with pagination parameters (`synology_drive_api/team_folder.go`). [[1]](diffhunk://#diff-ea26c2b6e4b8c716ebb9ac647cd0a3a6eca8bfaa7e4b9e52f840a105dfad196fL19-R24) [[2]](diffhunk://#diff-ea26c2b6e4b8c716ebb9ac647cd0a3a6eca8bfaa7e4b9e52f840a105dfad196fL37-R42)

These changes collectively improve the scalability, maintainability, and testability of the Synology Drive API integration.