### PR TITLE
synology_drive_api: Add robust HTTP GET retry logic and comprehensive tests

### DIFF
--- a/synology_drive_api/session_test.go
+++ b/synology_drive_api/session_test.go
@@ -1,7 +1,11 @@
 package synology_drive_api
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,4 +80,179 @@ func TestBuildUrl(t *testing.T) {
 	url = session.buildUrl("test.cgi", params)
 	assert.Equal(t, "value1", url.Query().Get("param1"), "URL should contain correct param1 value")
 	assert.Equal(t, "value2", url.Query().Get("param2"), "URL should contain correct param2 value")
+}
+
+// testSleeper is a test implementation of the sleeper interface
+// testSleeper is a mock implementation of the sleeper interface for testing
+type testSleeper struct {
+	sleepCalls []time.Duration
+}
+
+// Sleep records the sleep duration
+func (t *testSleeper) Sleep(d time.Duration) {
+	t.sleepCalls = append(t.sleepCalls, d)
+}
+
+// testServer is a test HTTP server that can be used to test the Synology API client
+type testServer struct {
+	server    *httptest.Server
+	requests  []*http.Request
+	responses []response
+	mu        sync.Mutex
+	callCount int
+}
+
+type response struct {
+	statusCode int
+	body       string
+}
+
+// newTestServer creates a new test server
+func newTestServer() *testServer {
+	ts := &testServer{
+		requests:  make([]*http.Request, 0),
+		responses: make([]response, 0),
+	}
+	ts.server = httptest.NewServer(http.HandlerFunc(ts.handler))
+	ts.server.URL = ts.server.URL + "/webapi/"
+	return ts
+}
+
+// handler handles incoming HTTP requests
+func (ts *testServer) handler(w http.ResponseWriter, r *http.Request) {
+	ts.mu.Lock()
+
+	// Clone the request to avoid data races
+	req := *r
+	req.Header = make(http.Header)
+	for k, v := range r.Header {
+		req.Header[k] = v
+	}
+	ts.requests = append(ts.requests, &req)
+
+	// If we have responses configured, use them
+	if ts.callCount < len(ts.responses) {
+		resp := ts.responses[ts.callCount]
+		ts.callCount++
+		ts.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.statusCode)
+		w.Write([]byte(resp.body))
+		return
+	}
+
+	ts.mu.Unlock()
+
+	// Default to 500 error if no response is configured
+	http.Error(w, "no response configured", http.StatusInternalServerError)
+}
+
+// addResponse adds a response to the test server
+func (ts *testServer) addResponse(statusCode int, body string) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	ts.responses = append(ts.responses, response{
+		statusCode: statusCode,
+		body:       body,
+	})
+}
+
+// close closes the test server
+func (ts *testServer) close() {
+	if ts.server != nil {
+		ts.server.Close()
+	}
+}
+
+func TestHTTPGetJSONWithRetry_SuccessOnFirstTry(t *testing.T) {
+	// Setup test server
+	ts := newTestServer()
+	defer ts.close()
+
+	// Add a successful response
+	ts.addResponse(http.StatusOK, `{"success": true}`)
+
+	// Create a test session with a custom HTTP client that uses our test server
+	session, err := NewSynologySession("test", "test", ts.server.URL)
+	require.NoError(t, err)
+
+	// Replace the HTTP client with one that uses our test server
+	session.http_client = *ts.server.Client()
+
+	// Create a test sleeper
+	sleeper := &testSleeper{}
+
+	// Call the method under test
+	resp, err := session.httpGetJSONWithRetry("test.cgi", map[string]string{"key": "value"}, 3, time.Second, sleeper)
+
+	// Verify results
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, sleeper.sleepCalls, "should not sleep on first success")
+	assert.Len(t, ts.requests, 1, "should make one request")
+}
+
+func TestHTTPGetJSONWithRetry_SuccessOnRetry(t *testing.T) {
+	var requestCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		t.Logf("Request path: %s", r.URL.Path)
+		if requestCount == 1 {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"success": true}`))
+	}))
+	defer ts.Close()
+
+	// Use a base URL that matches what the production code expects
+	baseURL := ts.URL + "/webapi"
+	session, err := NewSynologySession("test", "test", baseURL)
+	require.NoError(t, err)
+	session.http_client = *ts.Client()
+	sleeper := &testSleeper{}
+
+	resp, err := session.httpGetJSONWithRetry("test.cgi", map[string]string{"key": "value"}, 1, time.Second, sleeper)
+
+	t.Logf("Handler was called %d times", requestCount)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, sleeper.sleepCalls, 1, "should sleep once before retry")
+	assert.Equal(t, time.Second, sleeper.sleepCalls[0], "should sleep for the specified duration")
+	assert.Equal(t, 2, requestCount, "handler should be called twice (1 fail, 1 success)")
+}
+
+func TestHTTPGetJSONWithRetry_AllAttemptsFail(t *testing.T) {
+	// Setup test server
+	ts := newTestServer()
+	defer ts.close()
+
+	// Add 4 failure responses
+	for i := 0; i < 4; i++ {
+		ts.addResponse(http.StatusInternalServerError, `{"error": {"code": 500, "message": "temporary error"}}`)
+	}
+
+	// Create a test session with a custom HTTP client that uses our test server
+	session, err := NewSynologySession("test", "test", ts.server.URL)
+	require.NoError(t, err)
+
+	// Replace the HTTP client with one that uses our test server
+	session.http_client = *ts.server.Client()
+
+	// Create a test sleeper
+	sleeper := &testSleeper{}
+
+	// Call the method under test with maxRetries=3 (total 4 attempts)
+	resp, err := session.httpGetJSONWithRetry("test.cgi", map[string]string{"key": "value"}, 3, time.Second, sleeper)
+
+	// Verify results
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "after 4 attempts")
+	assert.Len(t, sleeper.sleepCalls, 3, "should sleep before each retry")
 }


### PR DESCRIPTION
This pull request introduces retry logic for HTTP GET requests in the Synology Drive API client and adds comprehensive testing for the new functionality. The main changes include the implementation of retry logic, the addition of a mockable sleeper interface, and the creation of a test framework to validate retry behavior.

### Enhancements to HTTP GET requests:
* Added a new `httpGetJSONWithRetry` method in `synology_drive_api/session.go` that retries requests on network errors, HTTP 5xx errors, and selected 4xx errors (e.g., 408, 429, 401, 403). The method uses a configurable retry count and delay, with a default of 3 retries and a 1-second delay.
* Introduced the `isRetryableStatus` helper function to determine which HTTP status codes should trigger a retry.

### Codebase modularization:
* Added a `sleeper` interface and its implementation, `realSleeper`, to allow for customizable sleep behavior during retries. This design enables mocking in tests.

### Testing framework for retry logic:
* Created a `testSleeper` mock implementation to track sleep calls during testing.
* Developed a `testServer` utility to simulate HTTP server responses, allowing for controlled testing of retry scenarios.
* Added test cases for `httpGetJSONWithRetry` to verify:
  - Success on the first attempt.
  - Success after retries.
  - Failure after exhausting all retries.