### PR TITLE
Make download_history thread safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO_BUILD := go build
 GO_TEST := go test
 
 # Declare phony targets that don't produce files
-.PHONY: build test clean run pre-commit
+.PHONY: build test test-unit test-full test-race clean run pre-commit
 
 # Build the export command
 build:
@@ -24,8 +24,12 @@ test-unit:
 test-integration:
 	$(GO_TEST) -tags=integration -count=1 ./synology_drive_api/...
 
-# Run all tests (unit + integration)
-test-full: test-unit test-integration
+# Run race tests (to find race conditions)
+test-race:
+	$(GO_TEST) -race -v -timeout=5s ./download_history/...
+
+# Run all tests (unit + integration + race)
+test-full: test-unit test-integration test-race
 
 # Clean up automatically generated files
 clean:

--- a/download_history/download_history.go
+++ b/download_history/download_history.go
@@ -278,20 +278,6 @@ func loadItemsFromReader(r io.Reader) (map[string]DownloadItem, error) {
 	return items, nil
 }
 
-// loadFromReader loads DownloadItems from JSON and updates the internal state.
-// It holds the lock only when updating the internal state.
-func (d *DownloadHistory) loadFromReader(r io.Reader) error {
-	items, err := loadItemsFromReader(r)
-	if err != nil {
-		return err
-	}
-
-	d.mu.Lock()
-	d.items = items
-	d.mu.Unlock()
-	return nil
-}
-
 // Load reads download history from the JSON file specified during initialization.
 // It returns an error if the file cannot be opened, contains invalid data,
 // or if Load() has already been called.

--- a/download_history/download_history.go
+++ b/download_history/download_history.go
@@ -2,6 +2,7 @@ package download_history
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,8 +14,30 @@ import (
 	synd "github.com/isseis/go-synology-office-exporter/synology_drive_api"
 )
 
-const HISTORY_VERSION = 2
-const HISTORY_MAGIC = "SYNOLOGY_OFFICE_EXPORTER"
+const (
+	HISTORY_VERSION = 2
+	HISTORY_MAGIC   = "SYNOLOGY_OFFICE_EXPORTER"
+)
+
+type state int
+
+const (
+	stateNew state = iota
+	stateLoading
+	stateReady
+	stateClosed
+)
+
+var (
+	// ErrAlreadyLoaded is returned when Load() is called more than once
+	ErrAlreadyLoaded = errors.New("already loaded")
+
+	// ErrNotReady is returned when an operation is attempted before Load()
+	ErrNotReady = errors.New("history not loaded, call Load() first")
+
+	// ErrAlreadyClosed is returned when Save() is called after Close()
+	ErrAlreadyClosed = errors.New("history is already closed")
+)
 
 type counter struct {
 	count int32
@@ -37,11 +60,13 @@ type ExportStats struct {
 }
 
 // DownloadHistory manages the download state and statistics.
+// It enforces a strict lifecycle: New -> Load -> (operations) -> Save/Close
 // All methods are safe for concurrent use.
 type DownloadHistory struct {
 	mu    sync.RWMutex
 	items map[string]DownloadItem
 	path  string
+	state state
 
 	// Counters are already thread-safe using atomic operations
 	DownloadCount counter
@@ -57,11 +82,16 @@ var ErrHistoryItemNotFound = fmt.Errorf("download history item not found")
 var ErrHistoryInvalidStatus = fmt.Errorf("download history item status is invalid")
 
 // MarkSkipped sets the status of an existing item to 'skipped'.
-// Returns an error if the item does not exist or if the item's status is not 'loaded'.
+// Returns an error if the item does not exist, if the item's status is not 'loaded',
+// or if the history is not in the ready state.
 // This method is safe for concurrent use.
 func (d *DownloadHistory) MarkSkipped(location string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
+	if d.state != stateReady {
+		return ErrNotReady
+	}
 
 	item, ok := d.items[location]
 	if !ok {
@@ -76,11 +106,16 @@ func (d *DownloadHistory) MarkSkipped(location string) error {
 }
 
 // SetDownloaded adds a new item with status 'downloaded' if it does not exist, or updates an existing item
-// to 'downloaded' if its current status is 'loaded'. Returns an error if the item exists and its status is not 'loaded'.
+// to 'downloaded' if its current status is 'loaded'. Returns an error if the item exists and its status is not 'loaded',
+// or if the history is not in the ready state.
 // This method is safe for concurrent use.
 func (d *DownloadHistory) SetDownloaded(location string, item DownloadItem) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
+	if d.state != stateReady {
+		return ErrNotReady
+	}
 
 	existing, ok := d.items[location]
 	if ok {
@@ -97,22 +132,35 @@ func (d *DownloadHistory) SetDownloaded(location string, item DownloadItem) erro
 }
 
 // GetStats returns the current export statistics.
-func (d *DownloadHistory) GetStats() ExportStats {
+// Returns an error if the history is not in the ready state.
+func (d *DownloadHistory) GetStats() (ExportStats, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.state != stateReady {
+		return ExportStats{}, ErrNotReady
+	}
 	return ExportStats{
 		Downloaded: d.DownloadCount.Get(),
 		Skipped:    d.SkippedCount.Get(),
 		Ignored:    d.IgnoredCount.Get(),
 		Errors:     d.ErrorCount.Get(),
-	}
+	}, nil
 }
 
 // GetItem looks up a DownloadItem by its key in a thread-safe manner.
 // It returns the item and true if found, or false if not found.
-func (d *DownloadHistory) GetItem(key string) (DownloadItem, bool) {
+// Returns an error if the history is not in the ready state.
+func (d *DownloadHistory) GetItem(key string) (DownloadItem, bool, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+
+	if d.state != stateReady {
+		return DownloadItem{}, false, ErrNotReady
+	}
+
 	item, exists := d.items[key]
-	return item, exists
+	return item, exists, nil
 }
 
 // jsonHeader is used for marshaling/unmarshaling metadata for download history JSON files.
@@ -156,6 +204,8 @@ type DownloadItem struct {
 // for later use with Save and Load methods.
 //
 // It validates that the path is not empty and could potentially be a valid file path.
+// The returned DownloadHistory is in the 'new' state and must be initialized with Load()
+// before any other operations can be performed.
 // Returns an error if the filename is invalid.
 func NewDownloadHistory(path string) (*DownloadHistory, error) {
 	// Basic validity check
@@ -171,6 +221,7 @@ func NewDownloadHistory(path string) (*DownloadHistory, error) {
 	history := &DownloadHistory{
 		items: make(map[string]DownloadItem),
 		path:  path,
+		state: stateNew,
 	}
 	return history, nil
 }
@@ -188,7 +239,7 @@ func (hdr *jsonHeader) validate() error {
 
 // loadItemsFromReader loads items from a reader without holding any locks.
 // It returns the loaded items and any error encountered.
-func (d *DownloadHistory) loadItemsFromReader(r io.Reader) (map[string]DownloadItem, error) {
+func loadItemsFromReader(r io.Reader) (map[string]DownloadItem, error) {
 	content, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read content: %w", err)
@@ -230,7 +281,7 @@ func (d *DownloadHistory) loadItemsFromReader(r io.Reader) (map[string]DownloadI
 // loadFromReader loads DownloadItems from JSON and updates the internal state.
 // It holds the lock only when updating the internal state.
 func (d *DownloadHistory) loadFromReader(r io.Reader) error {
-	items, err := d.loadItemsFromReader(r)
+	items, err := loadItemsFromReader(r)
 	if err != nil {
 		return err
 	}
@@ -242,58 +293,102 @@ func (d *DownloadHistory) loadFromReader(r io.Reader) error {
 }
 
 // Load reads download history from the JSON file specified during initialization.
-// It returns an error if the file cannot be opened or contains invalid data.
+// It returns an error if the file cannot be opened, contains invalid data,
+// or if Load() has already been called.
 // This method is safe for concurrent use.
 func (d *DownloadHistory) Load() error {
-	// First check if file exists without holding the lock
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.state != stateNew {
+		return ErrAlreadyLoaded
+	}
+
+	d.state = stateLoading
+
+	// Check if file exists
 	if _, err := os.Stat(d.path); os.IsNotExist(err) {
-		d.mu.Lock()
 		d.items = make(map[string]DownloadItem)
-		d.mu.Unlock()
+		d.state = stateReady
 		return nil
 	}
 
 	file, err := os.Open(d.path)
 	if err != nil {
+		d.state = stateNew // Reset state on error
 		return fmt.Errorf("file read error: %w", err)
 	}
-	defer file.Close()
 
-	return d.loadFromReader(file)
+	// Load items in a separate function to ensure file is closed
+	items, err := loadItemsFromReader(file)
+	file.Close()
+
+	if err != nil {
+		d.state = stateNew // Reset state on error
+		return err
+	}
+
+	d.items = items
+	d.state = stateReady
+	return nil
 }
 
 // Save writes the download history to the JSON file specified during initialization.
-// It returns an error if the file cannot be created or written to.
+// It returns an error if the file cannot be created or written to, or if the history
+// is not in the ready state.
 // This method is safe for concurrent use.
 func (d *DownloadHistory) Save() error {
+	d.mu.RLock()
+	if d.state != stateReady {
+		d.mu.RUnlock()
+		return ErrNotReady
+	}
+
 	dir := filepath.Dir(d.path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
+		d.mu.RUnlock()
 		return fmt.Errorf("file write error: %w", err)
 	}
 
 	file, err := os.Create(d.path)
 	if err != nil {
+		d.mu.RUnlock()
 		return fmt.Errorf("file write error: %w", err)
 	}
-	defer file.Close()
 
-	return d.saveToWriter(file)
+	// Copy the items we want to save while holding the read lock
+	items := make(map[string]DownloadItem, len(d.items))
+	for k, v := range d.items {
+		items[k] = v
+	}
+	d.mu.RUnlock()
+
+	// Now save the items without holding any locks
+	err = saveToWriter(file, items)
+	file.Close()
+
+	if err != nil {
+		// Try to clean up the file if there was an error
+		os.Remove(d.path)
+		return err
+	}
+
+	return nil
 }
 
-// saveToWriter writes the download history to the provided writer in JSON format.
-// This method is safe for concurrent use.
-func (d *DownloadHistory) saveToWriter(w io.Writer) error {
-	d.mu.RLock()
-	items := make([]jsonDownloadItem, 0, len(d.items))
-	for location, item := range d.items {
-		items = append(items, jsonDownloadItem{
+// saveToWriter writes the provided items to the writer in JSON format.
+// This function does not hold any locks and is safe to call with the items map.
+func saveToWriter(w io.Writer, items map[string]DownloadItem) error {
+	// Convert items to JSON structure
+	jsonItems := make([]jsonDownloadItem, 0, len(items))
+	for location, item := range items {
+		jsonItems = append(jsonItems, jsonDownloadItem{
 			Location:     location,
 			FileID:       item.FileID,
 			Hash:         item.Hash,
 			DownloadTime: item.DownloadTime.Format(time.RFC3339),
 		})
 	}
-	d.mu.RUnlock()
 
 	history := jsonDownloadHistory{
 		Header: jsonHeader{
@@ -301,7 +396,7 @@ func (d *DownloadHistory) saveToWriter(w io.Writer) error {
 			Magic:   HISTORY_MAGIC,
 			Created: time.Now().Format(time.RFC3339),
 		},
-		Items: items,
+		Items: jsonItems,
 	}
 
 	encoder := json.NewEncoder(w)
@@ -315,10 +410,15 @@ func (d *DownloadHistory) saveToWriter(w io.Writer) error {
 
 // GetObsoleteItems returns a slice of file paths that are marked as "loaded" in the history.
 // These represent files that exist in history but were not found in the current export.
+// Returns an error if the history is not in the ready state.
 // This method is safe for concurrent use.
-func (d *DownloadHistory) GetObsoleteItems() []string {
+func (d *DownloadHistory) GetObsoleteItems() ([]string, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+
+	if d.state != stateReady {
+		return nil, ErrNotReady
+	}
 
 	var obsolete []string
 	for path, item := range d.items {
@@ -326,5 +426,5 @@ func (d *DownloadHistory) GetObsoleteItems() []string {
 			obsolete = append(obsolete, path)
 		}
 	}
-	return obsolete
+	return obsolete, nil
 }

--- a/download_history/download_history_test_helper.go
+++ b/download_history/download_history_test_helper.go
@@ -11,6 +11,7 @@ func NewDownloadHistoryForTest(items map[string]DownloadItem) *DownloadHistory {
 	dh := &DownloadHistory{
 		items:         items,
 		path:          "test-history.json",
+		state:         stateReady, // Set to ready state for testing
 		DownloadCount: counter{},
 		SkippedCount:  counter{},
 		IgnoredCount:  counter{},


### PR DESCRIPTION
This pull request introduces significant enhancements to the `DownloadHistory` module, focusing on lifecycle management, error handling, and test coverage. It also includes updates to the `Makefile` to improve test granularity and introduces new helper functions for testing. Below is a categorized summary of the most important changes:

### Lifecycle Management and Error Handling in `DownloadHistory`

* Introduced a `state` field in the `DownloadHistory` struct to enforce a strict lifecycle (`New -> Load -> Operations -> Save/Close`). Added corresponding constants (`stateNew`, `stateLoading`, `stateReady`, `stateClosed`) and error types (`ErrAlreadyLoaded`, `ErrNotReady`, `ErrAlreadyClosed`) to handle invalid state transitions. [[1]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L16-R41) [[2]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60R64-R70)
* Updated methods like `Load`, `Save`, `MarkSkipped`, `SetDownloaded`, `GetStats`, `GetItem`, and `GetObsoleteItems` to check for the `stateReady` condition and return `ErrNotReady` if the state is invalid. [[1]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L60-R96) [[2]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L79-R120) [[3]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L100-R164) [[4]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60R394-R410)
* Refactored `Load` to reset the state to `stateNew` on errors and removed the internal `loadFromReader` method in favor of a standalone `loadItemsFromReader` function. [[1]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L230-R334) [[2]](diffhunk://#diff-867861ce28d08e05ed62017dd63fc00e431fa65d747a7ab2553ccf5b3118ad60L191-R243)

### Code Simplification and Maintenance

* Consolidated constants `HISTORY_VERSION` and `HISTORY_MAGIC` into a single `const` block, improving readability.
* Refactored the `saveToWriter` function to operate on a provided map of items, decoupling it from the `DownloadHistory` struct and improving testability.

### Test Enhancements

* Replaced direct calls to `NewDownloadHistory` in tests with a new `NewDownloadHistoryForTest` helper function for better test isolation. [[1]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L54-R54) [[2]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L79-L81)
* Updated tests for `loadItemsFromReader` to directly validate its functionality, removing dependencies on the `DownloadHistory` struct. This includes handling invalid JSON, unsupported versions, and duplicate locations. [[1]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L154-R155) [[2]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L181-R178) [[3]](diffhunk://#diff-80b7542d9f7b6003fc8aaa26d850dae960d5cf272412c706cc1ee43570a55458L265-R262)

### Makefile Updates

* Added new test targets (`test-unit`, `test-race`) and updated the `test-full` target to include race condition tests, improving the granularity and coverage of test execution. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L8-R8) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L27-R32)

These changes collectively enhance the robustness, maintainability, and testability of the `DownloadHistory` module.