### PR TITLE
feat: Add force download option for file exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Then run:
 Usage of synology-office-exporter:
   -dry_run
         If set, perform a dry run (no file downloads, only show statistics)
+  -force-download
+        If set, re-download files even if they exist and have matching hashes
   -output string
         Directory to save downloaded files (can be set via env SYNOLOGY_DOWNLOAD_DIR)
   -pass string

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -77,7 +77,11 @@ func init() {
 func printUsage() {
 	// Print standard flag usage
 	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
-	flag.PrintDefaults()
+	fmt.Fprintf(flag.CommandLine.Output(), "Flags:\n")
+	flag.VisitAll(func(f *flag.Flag) {
+		fmt.Fprintf(flag.CommandLine.Output(), "  -%s\n    \t%s\n", f.Name, f.Usage)
+	})
+	fmt.Fprintln(flag.CommandLine.Output())
 
 	// Print logger environment variables
 	fmt.Fprintln(flag.CommandLine.Output(), "\nLogger environment variables:")
@@ -113,6 +117,7 @@ func main() {
 	downloadDirFlag := flag.String("output", "", "Directory to save downloaded files")
 	sourcesFlag := flag.String("sources", "mydrive,teamfolder,shared", "Comma-separated list of sources to export (mydrive,teamfolder,shared)")
 	dryRunFlag := flag.Bool("dry_run", false, "If set, perform a dry run (no file downloads, only show statistics)")
+	forceDownloadFlag := flag.Bool("force-download", false, "If set, re-download files even if they exist and have matching hashes")
 
 	// Parse all flags
 	flag.Parse()
@@ -178,7 +183,10 @@ func main() {
 	}
 
 	log.Info("Synology Office Exporter started", "version", Version)
-	exporter, err := syndexp.NewExporter(user, pass, url, downloadDir, syndexp.WithDryRun(*dryRunFlag))
+	exporter, err := syndexp.NewExporter(user, pass, url, downloadDir,
+		syndexp.WithDryRun(*dryRunFlag),
+		syndexp.WithForceDownload(*forceDownloadFlag),
+	)
 	if err != nil {
 		log.Error("Failed to create exporter", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
This pull request introduces a new `--force-download` feature to the Synology Office Exporter, allowing users to re-download files even if they already exist and have matching hashes. It also includes updates to the `Exporter` class, related logic, and tests to support this feature. Below are the key changes:

### New Feature: `--force-download` Flag
* Added a new `--force-download` command-line flag in `cmd/export/main.go` to enable re-downloading files regardless of existing hashes.
* Updated the `Exporter` initialization in `cmd/export/main.go` to include the `WithForceDownload` option when the flag is set.

### Enhancements to `Exporter` Logic
* Introduced a `forceDownload` field in the `Exporter` struct to track the state of the `--force-download` option.
* Added the `WithForceDownload` option to configure the `forceDownload` field during the `Exporter` creation.
* Updated the `processFile` method in `synology_drive_exporter/exporter.go` to respect the `forceDownload` flag, skipping or re-downloading files based on its value. [[1]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047R281-R292) [[2]](diffhunk://#diff-0e384876278665c25cc2103cfb9d954dcc1485957cfc3db81d18a95dd8975047R301-R305)

### Documentation and Usage Updates
* Enhanced the `printUsage` function in `cmd/export/main.go` to display custom flag descriptions, improving usability.
* Clarified comments in `synology_drive_exporter/exporter.go` to document the behavior of `forceDownload`.

### Testing Improvements
* Added a comprehensive `TestForceDownload` test case in `exporter_test.go` to verify the behavior of the `--force-download` feature under different scenarios.
* Refactored existing tests to improve assertions and maintain consistency.

### Minor Code Adjustments
* Updated imports in `exporter_test.go` for clarity and alignment with Go conventions.
* Added a build tag to `exporter_test.go` for test-specific compilation.

Fix #71 