### PR TITLE
docs: Add instructions for tests.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,3 +26,17 @@
 - Comments on public structures, classes, variables and constantes in production code are compulsory.
 - Comments on test code and private elements are optional.
 - Trivial comments should be eliminated.
+
+## Test
+
+### Running tests
+
+- Add -tags=test when running test (e.g. go test -tags=test ./...)
+
+## Documentation
+
+- Update README.md when adding new features or making changes to existing code.
+- Documents should be in clear and concise English.
+- Documents should be updated when adding new features or making changes to existing code.
+- Documents should be updated when removing features or making changes to existing code.
+- Put documents in each package directory (exceptions: README.md should be in the root directory)


### PR DESCRIPTION
This pull request updates the `.github/copilot-instructions.md` file to provide clearer guidelines for testing and documentation. The changes introduce new sections for running tests and maintaining documentation.

### Additions to testing guidelines:
* Added a "Running tests" subsection with instructions to use `-tags=test` when running tests (e.g., `go test -tags=test ./...`).

### Additions to documentation guidelines:
* Added a "Documentation" section emphasizing the importance of updating `README.md` and other documents when adding, modifying, or removing features.
* Specified that documentation should be written in clear and concise English.
* Clarified that `README.md` should reside in the root directory, while other documents should be placed in their respective package directories.