### PR TITLE
refactor(synology_drive_exporter): migrate to unified logger system

### DIFF
--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -186,6 +186,7 @@ func main() {
 	exporter, err := syndexp.NewExporter(user, pass, url, downloadDir,
 		syndexp.WithDryRun(*dryRunFlag),
 		syndexp.WithForceDownload(*forceDownloadFlag),
+		syndexp.WithLogger(syndexp.NewLoggerAdapter(log)),
 	)
 	if err != nil {
 		log.Error("Failed to create exporter", "error", err)

--- a/synology_drive_exporter/export_processor.go
+++ b/synology_drive_exporter/export_processor.go
@@ -51,7 +51,7 @@ func (e *Exporter) processItem(item ExportItem, history *dh.DownloadHistory) {
 func (e *Exporter) processFile(item ExportItem, history *dh.DownloadHistory) {
 	exportName := synd.GetExportFileName(item.DisplayPath)
 	if exportName == "" {
-		fmt.Printf("Skip (not exportable): %s\n", item.DisplayPath)
+		e.getLogger().Info("Skipping non-exportable file", "path", item.DisplayPath)
 		history.IgnoredCount.Increment()
 		return
 	}
@@ -61,29 +61,29 @@ func (e *Exporter) processFile(item ExportItem, history *dh.DownloadHistory) {
 	// Check if we should skip based on hash and forceDownload flag
 	prev, downloaded, err := history.GetItem(localPath)
 	if err != nil {
-		fmt.Printf("Error checking history for %s: %v\n", localPath, err)
+		e.getLogger().Error("Failed to check download history", "path", localPath, "error", err)
 		history.ErrorCount.Increment()
 		return
 	}
 
 	// Skip if file exists, hashes match, and we're not forcing a re-download
 	if !e.forceDownload && downloaded && prev.Hash == item.Hash {
-		fmt.Printf("[DEBUG] hash skip: localPath=%s, prev.Hash=%s, item.Hash=%s, prev.DownloadStatus=%s\n", localPath, prev.Hash, item.Hash, prev.DownloadStatus)
-		fmt.Printf("Skip (already exported and hash unchanged): %s\n", localPath)
+		e.getLogger().Debug("Skipping file due to unchanged hash", "path", localPath, "prev_hash", prev.Hash, "current_hash", item.Hash, "status", prev.DownloadStatus)
+		e.getLogger().Info("Skipping already exported file with unchanged hash", "path", localPath)
 		history.SkippedCount.Increment()
 		err := history.MarkSkipped(localPath)
 		if err != nil {
-			fmt.Printf("Warning: could not mark as skipped: %v\n", err)
+			e.getLogger().Warn("Failed to mark file as skipped in history", "path", localPath, "error", err)
 		}
 		return
 	}
 
 	// If we're forcing a download and the file exists, log that we're re-downloading
 	if e.forceDownload && downloaded {
-		fmt.Printf("Re-downloading (--force-download): %s\n", localPath)
+		e.getLogger().Info("Re-downloading file due to force-download option", "path", localPath)
 	}
 	if e.IsDryRun() {
-		fmt.Printf("[DRY RUN] Would export file: %s\n", exportName)
+		e.getLogger().Info("Dry run: would export file", "export_name", exportName)
 		// Simulate successful export for statistics only
 		newItem := dh.DownloadItem{
 			FileID:       item.FileID,
@@ -92,26 +92,26 @@ func (e *Exporter) processFile(item ExportItem, history *dh.DownloadHistory) {
 		}
 		errHistory := history.SetDownloaded(localPath, newItem)
 		if errHistory != nil {
-			fmt.Printf("Warning: could not update download history: %v\n", errHistory)
+			e.getLogger().Warn("Failed to update download history in dry run", "path", localPath, "error", errHistory)
 		}
 		history.DownloadCount.Increment()
 		return
 	}
-	fmt.Printf("Exporting file: %s\n", exportName)
+	e.getLogger().Info("Exporting file", "export_name", exportName)
 	resp, err := e.session.Export(item.FileID)
 	if err != nil {
-		fmt.Printf("failed to export %s: %v\n", exportName, err)
+		e.getLogger().Error("Failed to export file", "export_name", exportName, "error", err)
 		history.ErrorCount.Increment()
 		return
 	}
 	downloadPath := filepath.Join(e.downloadDir, localPath)
 	if err := e.fs.CreateFile(downloadPath, resp.Content, 0755, 0644); err != nil {
-		fmt.Printf("failed to write file %s: %v\n", downloadPath, err)
+		e.getLogger().Error("Failed to write file", "path", downloadPath, "error", err)
 		history.ErrorCount.Increment()
 		return
 	}
 
-	fmt.Printf("Saved to: %s\n", downloadPath)
+	e.getLogger().Info("File exported successfully", "path", downloadPath)
 	// Update download history: if entry exists, mark as downloaded (only if loaded); otherwise add as new downloaded entry.
 	newItem := dh.DownloadItem{
 		FileID:       item.FileID,
@@ -121,7 +121,7 @@ func (e *Exporter) processFile(item ExportItem, history *dh.DownloadHistory) {
 	// SetDownloaded: add new entry or update existing (if loaded) to 'downloaded'.
 	errHistory := history.SetDownloaded(localPath, newItem)
 	if errHistory != nil {
-		fmt.Printf("Warning: could not update download history: %v\n", errHistory)
+		e.getLogger().Warn("Failed to update download history", "path", localPath, "error", errHistory)
 	}
 	history.DownloadCount.Increment()
 }
@@ -131,7 +131,7 @@ func (e *Exporter) processDirectory(item ExportItem, history *dh.DownloadHistory
 	// Use listAll to handle pagination automatically
 	items, err := listAll(e.session, item.FileID)
 	if err != nil {
-		fmt.Printf("Failed to list directory %s: %v\n", item.DisplayPath, err)
+		e.getLogger().Error("Failed to list directory", "path", item.DisplayPath, "error", err)
 		history.ErrorCount.Increment()
 		return
 	}

--- a/synology_drive_exporter/export_processor.go
+++ b/synology_drive_exporter/export_processor.go
@@ -69,7 +69,6 @@ func (e *Exporter) processFile(item ExportItem, history *dh.DownloadHistory) {
 	// Skip if file exists, hashes match, and we're not forcing a re-download
 	if !e.forceDownload && downloaded && prev.Hash == item.Hash {
 		e.getLogger().Debug("Skipping file due to unchanged hash", "path", localPath, "prev_hash", prev.Hash, "current_hash", item.Hash, "status", prev.DownloadStatus)
-		e.getLogger().Info("Skipping already exported file with unchanged hash", "path", localPath)
 		history.SkippedCount.Increment()
 		err := history.MarkSkipped(localPath)
 		if err != nil {

--- a/synology_drive_exporter/exporter_core.go
+++ b/synology_drive_exporter/exporter_core.go
@@ -8,10 +8,10 @@ import (
 
 // Logger defines the interface for logging operations within the exporter.
 type Logger interface {
-	Debug(msg string, args ...interface{})
-	Info(msg string, args ...interface{})
-	Warn(msg string, args ...interface{})
-	Error(msg string, args ...interface{})
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
 	FlushWebhook() error
 }
 
@@ -80,19 +80,19 @@ func (e *Exporter) GetLogger() Logger {
 // fallbackLogger provides a backward-compatible logging implementation.
 type fallbackLogger struct{}
 
-func (f *fallbackLogger) Debug(msg string, args ...interface{}) {
-	// Debug messages are silent for backward compatibility
+func (f *fallbackLogger) Debug(msg string, args ...any) {
+	fmt.Printf("[DEBUG] %s\n", formatLogMessage(msg, args...))
 }
 
-func (f *fallbackLogger) Info(msg string, args ...interface{}) {
+func (f *fallbackLogger) Info(msg string, args ...any) {
 	fmt.Printf("[INFO] %s\n", formatLogMessage(msg, args...))
 }
 
-func (f *fallbackLogger) Warn(msg string, args ...interface{}) {
+func (f *fallbackLogger) Warn(msg string, args ...any) {
 	fmt.Printf("[WARN] %s\n", formatLogMessage(msg, args...))
 }
 
-func (f *fallbackLogger) Error(msg string, args ...interface{}) {
+func (f *fallbackLogger) Error(msg string, args ...any) {
 	fmt.Printf("[ERROR] %s\n", formatLogMessage(msg, args...))
 }
 
@@ -101,7 +101,7 @@ func (f *fallbackLogger) FlushWebhook() error {
 }
 
 // formatLogMessage formats the log message with key-value pairs.
-func formatLogMessage(msg string, args ...interface{}) string {
+func formatLogMessage(msg string, args ...any) string {
 	result := msg
 	for i := 0; i < len(args); i += 2 {
 		if i+1 < len(args) {

--- a/synology_drive_exporter/exporter_core.go
+++ b/synology_drive_exporter/exporter_core.go
@@ -101,6 +101,8 @@ func (f *fallbackLogger) FlushWebhook() error {
 }
 
 // formatLogMessage formats the log message with key-value pairs.
+// It concatenates the message with additional key-value pairs provided in args.
+// In case of an odd number of args, the last one is ignored.
 func formatLogMessage(msg string, args ...any) string {
 	result := msg
 	for i := 0; i < len(args); i += 2 {

--- a/synology_drive_exporter/exporter_core.go
+++ b/synology_drive_exporter/exporter_core.go
@@ -6,11 +6,21 @@ import (
 	synd "github.com/isseis/go-synology-office-exporter/synology_drive_api"
 )
 
+// Logger defines the interface for logging operations within the exporter.
+type Logger interface {
+	Debug(msg string, args ...interface{})
+	Info(msg string, args ...interface{})
+	Warn(msg string, args ...interface{})
+	Error(msg string, args ...interface{})
+	FlushWebhook() error
+}
+
 // Exporter handles exporting files from Synology Drive, maintaining download history and file system abstraction.
 type Exporter struct {
 	session     SessionInterface
 	downloadDir string // Directory where downloaded files will be saved
 	fs          FileSystemOperations
+	logger      Logger // Logger for structured logging
 
 	// dryRun controls whether file operations are performed. Immutable after construction.
 	// Default is false.
@@ -40,9 +50,65 @@ func WithForceDownload(force bool) ExporterOption {
 	}
 }
 
+// WithLogger sets the logger for Exporter.
+// If not set, a fallback logger will be used for backward compatibility.
+func WithLogger(log Logger) ExporterOption {
+	return func(e *Exporter) {
+		e.logger = log
+	}
+}
+
 // IsDryRun returns true if the exporter is in dry-run mode.
 func (e *Exporter) IsDryRun() bool {
 	return e.dryRun
+}
+
+// getLogger returns the logger, falling back to a default logger if none is set.
+func (e *Exporter) getLogger() Logger {
+	if e.logger != nil {
+		return e.logger
+	}
+	return &fallbackLogger{}
+}
+
+// GetLogger returns the logger instance for testing purposes.
+// This method is intended for testing and debugging only.
+func (e *Exporter) GetLogger() Logger {
+	return e.getLogger()
+}
+
+// fallbackLogger provides a backward-compatible logging implementation.
+type fallbackLogger struct{}
+
+func (f *fallbackLogger) Debug(msg string, args ...interface{}) {
+	// Debug messages are silent for backward compatibility
+}
+
+func (f *fallbackLogger) Info(msg string, args ...interface{}) {
+	fmt.Printf("[INFO] %s\n", formatLogMessage(msg, args...))
+}
+
+func (f *fallbackLogger) Warn(msg string, args ...interface{}) {
+	fmt.Printf("[WARN] %s\n", formatLogMessage(msg, args...))
+}
+
+func (f *fallbackLogger) Error(msg string, args ...interface{}) {
+	fmt.Printf("[ERROR] %s\n", formatLogMessage(msg, args...))
+}
+
+func (f *fallbackLogger) FlushWebhook() error {
+	return nil
+}
+
+// formatLogMessage formats the log message with key-value pairs.
+func formatLogMessage(msg string, args ...interface{}) string {
+	result := msg
+	for i := 0; i < len(args); i += 2 {
+		if i+1 < len(args) {
+			result += fmt.Sprintf(" %v=%v", args[i], args[i+1])
+		}
+	}
+	return result
 }
 
 // NewExporter constructs an Exporter with a real Synology session and the specified download directory. If downloadDir is empty, the current directory is used.
@@ -67,6 +133,7 @@ func NewExporterWithDependencies(session SessionInterface, downloadDir string, f
 		downloadDir: downloadDir,
 		fs:          fs,
 		dryRun:      false, // default
+		logger:      nil,   // will use fallback logger if not set
 	}
 	// Apply additional runtime options.
 	for _, opt := range opts {

--- a/synology_drive_exporter/logger_adapter.go
+++ b/synology_drive_exporter/logger_adapter.go
@@ -1,0 +1,33 @@
+package synology_drive_exporter
+
+import "github.com/isseis/go-synology-office-exporter/logger"
+
+// loggerAdapter adapts logger.Logger to synology_drive_exporter.Logger interface.
+type loggerAdapter struct {
+	logger logger.Logger
+}
+
+// NewLoggerAdapter creates a new adapter that wraps logger.Logger.
+func NewLoggerAdapter(log logger.Logger) Logger {
+	return &loggerAdapter{logger: log}
+}
+
+func (a *loggerAdapter) Debug(msg string, args ...interface{}) {
+	a.logger.Debug(msg, args...)
+}
+
+func (a *loggerAdapter) Info(msg string, args ...interface{}) {
+	a.logger.Info(msg, args...)
+}
+
+func (a *loggerAdapter) Warn(msg string, args ...interface{}) {
+	a.logger.Warn(msg, args...)
+}
+
+func (a *loggerAdapter) Error(msg string, args ...interface{}) {
+	a.logger.Error(msg, args...)
+}
+
+func (a *loggerAdapter) FlushWebhook() error {
+	return a.logger.FlushWebhook()
+}

--- a/synology_drive_exporter/logger_adapter.go
+++ b/synology_drive_exporter/logger_adapter.go
@@ -12,19 +12,19 @@ func NewLoggerAdapter(log logger.Logger) Logger {
 	return &loggerAdapter{logger: log}
 }
 
-func (a *loggerAdapter) Debug(msg string, args ...interface{}) {
+func (a *loggerAdapter) Debug(msg string, args ...any) {
 	a.logger.Debug(msg, args...)
 }
 
-func (a *loggerAdapter) Info(msg string, args ...interface{}) {
+func (a *loggerAdapter) Info(msg string, args ...any) {
 	a.logger.Info(msg, args...)
 }
 
-func (a *loggerAdapter) Warn(msg string, args ...interface{}) {
+func (a *loggerAdapter) Warn(msg string, args ...any) {
 	a.logger.Warn(msg, args...)
 }
 
-func (a *loggerAdapter) Error(msg string, args ...interface{}) {
+func (a *loggerAdapter) Error(msg string, args ...any) {
 	a.logger.Error(msg, args...)
 }
 


### PR DESCRIPTION
This pull request introduces structured logging to the Synology Drive Exporter by integrating a new `Logger` interface and replacing existing unstructured logging with structured log messages. The changes aim to improve log clarity, flexibility, and maintainability. A fallback logger is also provided for backward compatibility.

### Logging Integration and Refactoring:
* Introduced a `Logger` interface with methods for structured logging (`Debug`, `Info`, `Warn`, `Error`) and a `FlushWebhook` method. (`synology_drive_exporter/exporter_core.go`, [synology_drive_exporter/exporter_core.goR9-R23](diffhunk://#diff-b9b44175e33319484c9eaf8cb8a07651225dd5616df04a5c5f3c5b15428e484fR9-R23))
* Added a `logger` field to the `Exporter` struct and implemented a `WithLogger` option to allow custom logger injection. A fallback logger is used when no logger is provided. (`synology_drive_exporter/exporter_core.go`, [[1]](diffhunk://#diff-b9b44175e33319484c9eaf8cb8a07651225dd5616df04a5c5f3c5b15428e484fR53-R113) [[2]](diffhunk://#diff-b9b44175e33319484c9eaf8cb8a07651225dd5616df04a5c5f3c5b15428e484fR136)
* Replaced all `fmt.Printf` and `log` calls with structured logging using the new `Logger` interface in methods like `processFile`, `processDirectory`, and `removeFile`. (`synology_drive_exporter/export_processor.go`, [[1]](diffhunk://#diff-d9636939e1646f314043537d07cb23ee4e7104fb549bff23435491bfde19ecc9L54-R54) [[2]](diffhunk://#diff-d9636939e1646f314043537d07cb23ee4e7104fb549bff23435491bfde19ecc9L64-R86) [[3]](diffhunk://#diff-d9636939e1646f314043537d07cb23ee4e7104fb549bff23435491bfde19ecc9L95-R114) [[4]](diffhunk://#diff-d9636939e1646f314043537d07cb23ee4e7104fb549bff23435491bfde19ecc9L124-R124) [[5]](diffhunk://#diff-d9636939e1646f314043537d07cb23ee4e7104fb549bff23435491bfde19ecc9L134-R134); `synology_drive_exporter/file_operations.go`, [[6]](diffhunk://#diff-3ec4d6bca684348c37548d659a39150790f6c4af84efb2001d8654d7b7ada431L15-R46)

### Logger Adapter:
* Added a `loggerAdapter` to bridge the new `Logger` interface with an external logger implementation. This allows seamless integration with existing logging systems. (`synology_drive_exporter/logger_adapter.go`, [synology_drive_exporter/logger_adapter.goR1-R33](diffhunk://#diff-a041cd93f9016420f1b7bbad148094e9eaab109f0a3041e9ede6351eb568d5c9R1-R33))

### Main Function Update:
* Updated the `main` function to pass a logger adapter to the exporter using the `WithLogger` option. (`cmd/export/main.go`, [cmd/export/main.goR189](diffhunk://#diff-ec447938ff5ceca7abc5424272d18e5a9c1cec2fdf3b0b45a42169d19e757de6R189))

These changes make the logging system more robust and extensible, while maintaining backward compatibility through a fallback logger.