### PR TITLE
docs: add guidance for running git commands with --no-pager

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,11 @@
 - Comments on test code and private elements are optional.
 - Trivial comments should be eliminated.
 
+## git
+
+### Running git commands
+- Use git commands with --no-pager option (e.g. git --no-pager diff --staged).
+
 ## Test
 
 ### Running tests


### PR DESCRIPTION
Include a new "Running git commands" section in the Copilot instructions specifying that all git invocations should use the `--no-pager` option (e.g. `git --no-pager diff --staged`). Otherwise unexpected paged output can be produced depending on user's shell environment settings.